### PR TITLE
fixed regex parsing for godot4 beta4

### DIFF
--- a/godot-codegen/src/godot_version.rs
+++ b/godot-codegen/src/godot_version.rs
@@ -28,7 +28,7 @@ pub struct GodotVersion {
 
 pub fn parse_godot_version(version_str: &str) -> Result<GodotVersion, Box<dyn Error>> {
     let regex = Regex::new(
-        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)\.(?:(?:official|custom_build)\.([a-f0-9]+)|official)"#,
+        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)4?\.(?:(?:official|custom_build)\.([a-f0-9]+)|official)"#,
     )?;
 
     let caps = regex.captures(version_str).ok_or("Regex capture failed")?;

--- a/godot-codegen/src/godot_version.rs
+++ b/godot-codegen/src/godot_version.rs
@@ -28,7 +28,7 @@ pub struct GodotVersion {
 
 pub fn parse_godot_version(version_str: &str) -> Result<GodotVersion, Box<dyn Error>> {
     let regex = Regex::new(
-        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)4?\.(?:(?:official|custom_build)\.([a-f0-9]+)|official)"#,
+        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)[0-9]*\.(?:(?:official|custom_build)\.([a-f0-9]+)|official)"#,
     )?;
 
     let caps = regex.captures(version_str).ok_or("Regex capture failed")?;


### PR DESCRIPTION
The regex parses the godot version in the format such as:
4.0.beta.official.e6751549c
For whatever reason, the godot 4 beta version (returned by $GODOT4_BIN --version) returns:
4.0.beta**4**.official.e6751549c
This results in the version regex to fail to match. This pull request simply adds an optional [0-9] to accept one or more digits after "beta" to match (which are ignored).

This only seems to affect recompilation -- compiling for the first time does not have this issue. 
Additionally, it looks like there are generated files placed in godot-codegen/input/gen, instead of the target directory, which prevents ```cargo clean``` from removing the generated json file. This made this issue a bit more frustrating, since a clean rebuild was still using generated files from a previous build (meaning that only a fresh build would compile, but recompiling/clean compiling would not).
I don't want to submit another pull request changing this without understanding the rational, but this might be something worth changing.