### PR TITLE
fix(build): Builds on Mac would fail because the env variable `LLVM_PATH` wasn't hardcoded properly

### DIFF
--- a/godot-ffi/build.rs
+++ b/godot-ffi/build.rs
@@ -61,7 +61,7 @@ fn configure_platform_specific(builder: bindgen::Builder) -> bindgen::Builder {
     let target_vendor = env::var("CARGO_CFG_TARGET_VENDOR").unwrap();
     if target_vendor == "apple" {
         eprintln!("Build selected for macOS.");
-        let path = env::var("LLVM_PATH ").expect("env var 'LLVM_PATH' not set");
+        let path = env::var("LLVM_PATH").expect("env var 'LLVM_PATH' not set");
 
         builder
             .clang_arg("-I")


### PR DESCRIPTION
Without the fix, I would run into build errors like the following:
```
   Compiling godot-ffi v0.1.0 (https://github.com/godot-rust/gdextension?branch=master#1dcbc034)
error: failed to run custom build command for `godot-ffi v0.1.0 (https://github.com/godot-rust/gdextension?branch=master#1dcbc034)`

Caused by:
  process didn't exit successfully: `/Users/user/Projects/nehu-game-prototype/target/debug/build/godot-ffi-6762956da28a16f1/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=../godot-codegen/input/gdnative_interface.h

  --- stderr
  Build selected for macOS.
  thread 'main' panicked at 'env var 'LLVM_PATH' not set: NotPresent', /Users/user/.cargo/git/checkouts/gdextension-25c68fb170a9fb9d/1dcbc03/godot-ffi/build.rs:64:43
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It seems like the hardcoded variable name had a space in it, which made it impossible to be resolved at build time.