### PR TITLE
feat(example): Add a reference to the extension library on x86_64 Mac platforms

### DIFF
--- a/examples/dodge-the-creeps/godot/DodgeTheCreeps.gdextension
+++ b/examples/dodge-the-creeps/godot/DodgeTheCreeps.gdextension
@@ -3,4 +3,5 @@ entry_symbol = "gdextension_rust_init"
 
 [libraries]
 linux.64 = "res://../../../target/debug/libdodge_the_creeps.so"
+macos.64 = "res://../../../target/debug/libdodge_the_creeps.dylib"
 windows.64 = "res://../../../target/debug/dodge_the_creeps.dll"


### PR DESCRIPTION
It seems the example works well on Mac; we were just missing a reference to the library.

Tested on a MacBook Pro mid 2014 (2.6 GHz Intel Core i5, 8 GB RAM, Intel Iris 1536 MB graphics).

PS: I had to use the mobile renderer, that's probably because of https://github.com/godotengine/godot/issues/62322 and therefore most likely unrelated to godot-rust:
```properties
[rendering]
renderer/rendering_method="mobile"
```