### PR TITLE
Change "minimal" dependency feature to package feature

### DIFF
--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -7,6 +7,10 @@ publish = false
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = ["minimal"]
+minimal = ["godot/minimal"]
+
 [dependencies]
-godot = { path = "../../../godot", features = ["minimal"] }
+godot = { path = "../../../godot" }
 rand = "0.8"

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -8,11 +8,12 @@ rust-version = "1.63"
 crate-type = ["cdylib"]
 
 [features]
-default = []
+default = ["minimal"]
 trace = ["godot/trace"]
+minimal = ["godot/minimal"]
 
 [dependencies]
-godot = { path = "../../godot", features = ["minimal"] }
+godot = { path = "../../godot" }
 
 [build-dependencies]
 quote = "1"


### PR DESCRIPTION
When "minimal" was added as a feature, `examples` and `itest` included the `godot` package with the feature "minimal". 

As a result, when building the workspace, even if the workspace is compiled with `--no-default-features`, it will still only run `godot-codegen` with the "minimal" feature set. If we change it so that the dependency feature is enabled by a package feature which is on by default, we can then compile the workspace with `--no-default-features` and get the codegen for the full class set.