### PR TITLE
making revision number for parsing of godot version optional

### DIFF
--- a/godot-codegen/src/godot_version.rs
+++ b/godot-codegen/src/godot_version.rs
@@ -28,7 +28,7 @@ pub struct GodotVersion {
 
 pub fn parse_godot_version(version_str: &str) -> Result<GodotVersion, Box<dyn Error>> {
     let regex = Regex::new(
-        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)[0-9]*\.(?:(?:official|custom_build)\.([a-f0-9]+)|official)"#,
+        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)[0-9]*\.(?:(?:official|custom_build)(\.([a-f0-9]+))?|official)"#,
     )?;
 
     let caps = regex.captures(version_str).ok_or("Regex capture failed")?;


### PR DESCRIPTION
this might help for custom_builds without revision number like the one of nixpkgs.godot_4