### PR TITLE
wip: allow custom derive to work on generics

### DIFF
--- a/godot-macros/src/derive_godot_class.rs
+++ b/godot-macros/src/derive_godot_class.rs
@@ -34,7 +34,7 @@ pub fn transform(input: TokenStream) -> ParseResult<TokenStream> {
 
     let (godot_init_impl, create_fn);
     if struct_cfg.has_generated_init {
-        godot_init_impl = make_godot_init_impl(class_name, where_clause, generics, fields);
+        godot_init_impl = make_godot_init_impl(class_name, generics, where_clause, fields);
         create_fn = quote! { Some(#prv::callbacks::create::<#class_name>) };
     } else {
         godot_init_impl = TokenStream::new();
@@ -210,7 +210,7 @@ impl ExportedField {
     }
 }
 
-fn make_godot_init_impl(class_name: &Ident, where_clause: &Option<WhereClause>, generics: &Option<GenericParamList>, fields: Fields) -> TokenStream {
+fn make_godot_init_impl(class_name: &Ident, generics: &Option<GenericParamList>, where_clause: &Option<WhereClause>, fields: Fields) -> TokenStream {
     let base_init = if let Some(ExportedField { name, .. }) = fields.base_field {
         quote! { #name: base, }
     } else {

--- a/godot-macros/src/godot_api.rs
+++ b/godot-macros/src/godot_api.rs
@@ -278,9 +278,9 @@ fn transform_trait_impl(original_impl: Impl) -> Result<TokenStream, Error> {
         #original_impl
         #godot_init_impl
 
-        impl ::godot::private::You_forgot_the_attribute__godot_api for #class_name {}
+        impl #generics ::godot::private::You_forgot_the_attribute__godot_api for #class_name #generics #where_clause {}
 
-        impl ::godot::obj::cap::ImplementsGodotExt for #class_name {
+        impl #generics ::godot::obj::cap::ImplementsGodotExt for #class_name #generics #where_clause {
             fn __virtual_call(name: &str) -> ::godot::sys::GDNativeExtensionClassCallVirtual {
                 //println!("virtual_call: {}.{}", std::any::type_name::<Self>(), name);
 

--- a/godot-macros/src/util.rs
+++ b/godot-macros/src/util.rs
@@ -221,14 +221,7 @@ pub(crate) fn validate_impl(
 
     // impl Trait for Self -- validate Self
     if let Some(segment) = extract_typename(&original_impl.self_ty) {
-        if segment.generic_args.is_none() {
-            Ok(segment.ident)
-        } else {
-            bail(
-                format!("#[{attr}] for does currently not support generic arguments"),
-                &original_impl,
-            )
-        }
+        Ok(segment.ident)
     } else {
         bail(
             format!("#[{attr}] requires Self type to be a simple path"),

--- a/itest/godot/itest.gdextension
+++ b/itest/godot/itest.gdextension
@@ -4,3 +4,4 @@ entry_symbol = "itest_init"
 [libraries]
 linux.64 = "res://../../target/debug/libitest.so"
 windows.64 = "res://../../target/debug/itest.dll"
+macos.x86_64 = "res://../../target/debug/itest.dylib"

--- a/itest/godot/itest.gdextension
+++ b/itest/godot/itest.gdextension
@@ -4,4 +4,4 @@ entry_symbol = "itest_init"
 [libraries]
 linux.64 = "res://../../target/debug/libitest.so"
 windows.64 = "res://../../target/debug/itest.dll"
-macos.x86_64 = "res://../../target/debug/itest.dylib"
+macos.x86_64 = "res://../../target/debug/libitest.dylib"

--- a/itest/rust/src/generic_struct_test.rs
+++ b/itest/rust/src/generic_struct_test.rs
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#![allow(dead_code)]
+
+use godot::bind::{godot_api, GodotClass, GodotExt};
+use godot::builtin::GodotString;
+use godot::obj::{Base, Gd};
+use godot::test::itest;
+use std::marker::PhantomData;
+
+/// A simple abstractio to see if we can derive GodotClass for Generic Structs
+trait Abstraction {}
+struct A {}
+struct B {}
+impl Abstraction for A {}
+impl Abstraction for B {}
+
+
+#[derive(GodotClass, Debug)]
+#[class(init, base=Node)]
+struct GenericStructTest<T: Abstraction> {
+    #[base]
+    some_base: Base<Node>,
+    // Use phantom data so we're _only_ testing the generic aspect
+    phantom_data: PhantomData<T>
+}
+
+#[godot_api]
+impl GenericStructTest {}
+
+#[godot_api]
+impl GodotExt for GenericStructTest {}
+
+pub(crate) fn run() -> bool {
+    let mut ok = true;
+    ok &= test_to_string();
+    ok
+}
+
+// pub(crate) fn register() {
+//     godot::register_class::<VirtualMethodTest>();
+// }
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
+
+#[itest]
+fn test_to_string() {
+    let _obj1 = Gd::<GenericStructTest<A>>::new_default();
+    dbg!(_obj1);
+    let _obj2 = Gd::<GenericStructTest<B>>::new_default();
+    dbg!(_obj2);
+}

--- a/itest/rust/src/generic_struct_test.rs
+++ b/itest/rust/src/generic_struct_test.rs
@@ -6,15 +6,18 @@
 
 #![allow(dead_code)]
 
+use std::fmt::Debug;
 use godot::bind::{godot_api, GodotClass, GodotExt};
-use godot::builtin::GodotString;
+use godot::engine::Node;
 use godot::obj::{Base, Gd};
 use godot::test::itest;
 use std::marker::PhantomData;
 
 /// A simple abstractio to see if we can derive GodotClass for Generic Structs
 trait Abstraction {}
+#[derive(Debug)]
 struct A {}
+#[derive(Debug)]
 struct B {}
 impl Abstraction for A {}
 impl Abstraction for B {}
@@ -22,7 +25,7 @@ impl Abstraction for B {}
 
 #[derive(GodotClass, Debug)]
 #[class(init, base=Node)]
-struct GenericStructTest<T: Abstraction> {
+struct GenericStructTest<T> where T: Abstraction + Debug {
     #[base]
     some_base: Base<Node>,
     // Use phantom data so we're _only_ testing the generic aspect
@@ -30,10 +33,14 @@ struct GenericStructTest<T: Abstraction> {
 }
 
 #[godot_api]
-impl GenericStructTest {}
+impl<T> GenericStructTest<T> where T: Abstraction + Debug {
+    fn get_phantom_data(&self) -> String {
+        format!("{:?}", self.phantom_data)
+    }
+}
 
 #[godot_api]
-impl GodotExt for GenericStructTest {}
+impl<T> GodotExt for GenericStructTest<T> where T: Abstraction + Debug {}
 
 pub(crate) fn run() -> bool {
     let mut ok = true;

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -12,6 +12,7 @@ use std::panic::UnwindSafe;
 mod base_test;
 mod enum_test;
 mod gdscript_ffi_test;
+mod generic_struct_test;
 mod node_test;
 mod object_test;
 mod singleton_test;
@@ -24,6 +25,7 @@ fn run_tests() -> bool {
     let mut ok = true;
     ok &= base_test::run();
     ok &= gdscript_ffi_test::run();
+    ok &= generic_struct_test::run();
     ok &= node_test::run();
     ok &= enum_test::run();
     ok &= object_test::run();


### PR DESCRIPTION
## What

Gets any Generics and Where clauses on the type we're deriving additional functionality for and adds them to the derived code.

This needs checking over as I'm not 100% sure what I've done is right, however, what I'm aiming to do in this PR is allow the custom derive macros to work over generic items and where clauses.

## Why

What I'd like to do is allow my code to be tested somewhat in isolation from the library code, see #36. One possible way to do this might be to allow `Godotclass::base` to be a generic item that does not need to be tied to the godot engine. Eg:

```rust
#[derive(GodotClass, Debug)]
#[class(base = Node)]
pub struct AppState<B: AbstractBase> {
    #[base]
    base: B,
    state: State,
}
```

`AbstractBase` can then be a trait that has only the methods I need for my code and that mirror the signature of Base.

```rust
use godot::prelude::*;
use thiserror::Error;
use godot::engine::global::Error as GodotError;

#[derive(Error, Debug)]
pub enum Error {
    #[error("Godot Error")]
    GodotError(GodotError),
}

impl From<GodotError> for Error {
    fn from(error: GodotError) -> Self {
        Error::GodotError(error)
    }
}

pub trait AbstractBase {
    fn emit_signal(&mut self, signal: &str, varargs: &[Variant]) -> Error;
}

impl<T: GodotClass> AbstractBase for Base<T> {
    fn emit_signal(&mut self, signal: &str, varargs: &[Variant]) -> Error {
        (self as Base<T>).emit_signal(signal, varargs)?
    }
}
```