### PR TITLE
fix: fixed version parsing for godot containing mono

### DIFF
--- a/godot-codegen/src/godot_version.rs
+++ b/godot-codegen/src/godot_version.rs
@@ -28,7 +28,7 @@ pub struct GodotVersion {
 
 pub fn parse_godot_version(version_str: &str) -> Result<GodotVersion, Box<dyn Error>> {
     let regex = Regex::new(
-        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)[0-9]*\.(?:(?:official|custom_build)\.([a-f0-9]+)|official)"#,
+        r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)[0-9]*\.(?:mono)\.(?:(?:official|custom_build)\.([a-f0-9]+)|official)"#,
     )?;
 
     let caps = regex.captures(version_str).ok_or("Regex capture failed")?;
@@ -73,6 +73,7 @@ fn test_godot_versions() {
         ("3.5.beta.custom_build.837f2c5f8", 3, 5, 0, "beta", s("837f2c5f8")),
         ("4.0.dev.custom_build.e7e9e663b", 4, 0, 0, "dev", s("e7e9e663b")),
         ("4.0.alpha.custom_build.faddbcfc0", 4, 0, 0, "alpha", s("faddbcfc0")),
+        ("4.0.beta8.mono.custom_build.b28ddd918", 4, 0, 0, "beta", s("b28ddd918")),
     ];
 
     let bad_versions = [


### PR DESCRIPTION
I have a custom build which contains mono. I suppose it should still work with rust so I added it in. I also added a test case.