### PR TITLE
Add variant type support to #[export] attributes

### DIFF
--- a/godot-core/src/obj/traits.rs
+++ b/godot-core/src/obj/traits.rs
@@ -100,6 +100,11 @@ pub mod cap {
         fn __register_methods();
     }
 
+    pub trait ImplementsGodotExports: GodotClass {
+        #[doc(hidden)]
+        fn __register_exports();
+    }
+
     /// Auto-implemented for `#[godot_api] impl GodotExt for MyClass` blocks
     pub trait ImplementsGodotExt: GodotClass {
         #[doc(hidden)]

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -374,13 +374,16 @@ pub mod callbacks {
         T::register_class(&mut class_builder);
     }
 
-    pub fn register_user_binds<T: cap::ImplementsGodotApi>(_class_builder: &mut dyn Any) {
+    pub fn register_user_binds<T: cap::ImplementsGodotApi + cap::ImplementsGodotExports>(
+        _class_builder: &mut dyn Any,
+    ) {
         // let class_builder = class_builder
         //     .downcast_mut::<ClassBuilder<T>>()
         //     .expect("bad type erasure");
 
         //T::register_methods(class_builder);
         T::__register_methods();
+        T::__register_exports();
     }
 }
 

--- a/godot-macros/src/derive_godot_class.rs
+++ b/godot-macros/src/derive_godot_class.rs
@@ -4,7 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::util::{bail, ensure_kv_empty, ident, path_is_single, KvMap, KvValue};
+use crate::util::{
+    bail, bail_error, ensure_kv_empty, ident, parse_kv_group, path_is_single, KvMap, KvValue,
+};
 use crate::{util, ParseResult};
 use proc_macro2::{Ident, Punct, Span, TokenStream};
 use quote::spanned::Spanned;
@@ -30,6 +32,8 @@ pub fn transform(input: TokenStream) -> ParseResult<TokenStream> {
     let prv = quote! { ::godot::private };
     let deref_impl = make_deref_impl(class_name, &fields);
 
+    let godot_exports_impl = make_exports_impl(class_name, &fields);
+
     let (godot_init_impl, create_fn);
     if struct_cfg.has_generated_init {
         godot_init_impl = make_godot_init_impl(class_name, fields);
@@ -49,6 +53,7 @@ pub fn transform(input: TokenStream) -> ParseResult<TokenStream> {
         }
 
         #godot_init_impl
+        #godot_exports_impl
         #deref_impl
 
         ::godot::sys::plugin_add!(__GODOT_PLUGIN_REGISTRY in #prv; #prv::ClassPlugin {
@@ -111,7 +116,7 @@ fn parse_struct_attributes(class: &Struct) -> ParseResult<ClassAttributes> {
 fn parse_fields(class: &Struct) -> ParseResult<Fields> {
     let mut all_field_names = vec![];
     let mut exported_fields = vec![];
-    let mut base_field = Option::<ExportedField>::None;
+    let mut base_field = Option::<Field>::None;
 
     let fields: Vec<(NamedField, Punct)> = match &class.fields {
         StructFields::Unit => {
@@ -142,9 +147,18 @@ fn parse_fields(class: &Struct) -> ParseResult<Fields> {
                             attr,
                         )?;
                     }
-                    base_field = Some(ExportedField::new(&field))
+                    base_field = Some(Field::new(&field))
                 } else if path == "export" {
-                    exported_fields.push(ExportedField::new(&field))
+                    match parse_kv_group(&attr.value) {
+                        Ok(export_kv) => {
+                            let exported_field =
+                                ExportedField::new_from_kv(Field::new(&field), &attr, export_kv)?;
+                            exported_fields.push(exported_field);
+                        }
+                        Err(error) => {
+                            return Err(error);
+                        }
+                    }
                 }
             }
         }
@@ -158,6 +172,7 @@ fn parse_fields(class: &Struct) -> ParseResult<Fields> {
     Ok(Fields {
         all_field_names,
         base_field,
+        exported_fields,
     })
 }
 
@@ -191,15 +206,16 @@ struct ClassAttributes {
 
 struct Fields {
     all_field_names: Vec<Ident>,
-    base_field: Option<ExportedField>,
+    base_field: Option<Field>,
+    exported_fields: Vec<ExportedField>,
 }
 
-struct ExportedField {
+struct Field {
     name: Ident,
     _ty: TyExpr,
 }
 
-impl ExportedField {
+impl Field {
     fn new(field: &NamedField) -> Self {
         Self {
             name: field.name.clone(),
@@ -208,8 +224,55 @@ impl ExportedField {
     }
 }
 
+struct ExportedField {
+    field: Field,
+    getter: String,
+    setter: String,
+}
+
+impl ExportedField {
+    pub fn new_from_kv(
+        field: Field,
+        attr: &Attribute,
+        mut map: KvMap,
+    ) -> Result<ExportedField, venial::Error> {
+        let export_getter: String;
+        let export_setter: String;
+        if let Some(getter) = map.remove("getter") {
+            if let KvValue::Lit(getter) = getter {
+                export_getter = getter;
+            } else {
+                return Err(bail_error(
+                    "#[property] attribute with a non-literal getter",
+                    attr,
+                ));
+            }
+        } else {
+            return Err(bail_error("#[property] attribute without a getter", attr));
+        }
+        if let Some(setter) = map.remove("setter") {
+            if let KvValue::Lit(setter) = setter {
+                export_setter = setter;
+            } else {
+                return Err(bail_error(
+                    "#[property] attribute with a non-literal setter",
+                    attr,
+                ));
+            }
+        } else {
+            return Err(bail_error("#[property] attribute without a setter", attr));
+        }
+        ensure_kv_empty(map, attr.__span())?;
+        return Ok(ExportedField {
+            field,
+            getter: export_getter,
+            setter: export_setter,
+        });
+    }
+}
+
 fn make_godot_init_impl(class_name: &Ident, fields: Fields) -> TokenStream {
-    let base_init = if let Some(ExportedField { name, .. }) = fields.base_field {
+    let base_init = if let Some(Field { name, .. }) = fields.base_field {
         quote! { #name: base, }
     } else {
         TokenStream::new()
@@ -232,7 +295,7 @@ fn make_godot_init_impl(class_name: &Ident, fields: Fields) -> TokenStream {
 }
 
 fn make_deref_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
-    let base_field = if let Some(ExportedField { name, .. }) = &fields.base_field {
+    let base_field = if let Some(Field { name, .. }) = &fields.base_field {
         name
     } else {
         return TokenStream::new();
@@ -249,6 +312,50 @@ fn make_deref_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
         impl std::ops::DerefMut for #class_name {
             fn deref_mut(&mut self) -> &mut Self::Target {
                 &mut *self.#base_field
+            }
+        }
+    }
+}
+
+fn make_exports_impl(class_name: &Ident, fields: &Fields) -> TokenStream {
+    let export_tokens = fields
+        .exported_fields
+        .iter()
+        .map(|exported_field: &ExportedField| {
+            use std::str::FromStr;
+            let name = exported_field.field.name.to_string();
+            let getter = proc_macro2::Literal::from_str(&exported_field.getter).unwrap();
+            let setter = proc_macro2::Literal::from_str(&exported_field.setter).unwrap();
+            quote! {
+                let class_name = ::godot::builtin::StringName::from(#class_name::CLASS_NAME);
+                let property_info = ::godot::builtin::meta::PropertyInfo::new(
+                    ::godot::sys::VariantType::Int,
+                    ::godot::builtin::meta::ClassName::new::<#class_name>(),
+                    ::godot::builtin::StringName::from(#name),
+                );
+                let property_info_sys = property_info.property_sys();
+
+                let getter_string_name = ::godot::builtin::StringName::from(#getter);
+                let setter_string_name = ::godot::builtin::StringName::from(#setter);
+                unsafe {
+                    ::godot::sys::interface_fn!(classdb_register_extension_class_property)(
+                        ::godot::sys::get_library(),
+                        class_name.string_sys(),
+                        std::ptr::addr_of!(property_info_sys),
+                        setter_string_name.string_sys(),
+                        getter_string_name.string_sys(),
+                    );
+                }
+            }
+        });
+    quote! {
+        impl ::godot::obj::cap::ImplementsGodotExports for #class_name {
+            fn __register_exports() {
+                #(
+                    {
+                        #export_tokens
+                    }
+                )*
             }
         }
     }

--- a/godot-macros/src/util.rs
+++ b/godot-macros/src/util.rs
@@ -22,6 +22,13 @@ pub fn strlit(s: &str) -> Literal {
     Literal::string(s)
 }
 
+pub fn bail_error<T>(msg: impl AsRef<str>, tokens: T) -> Error
+where
+    T: Spanned,
+{
+    Error::new_at_span(tokens.__span(), msg.as_ref())
+}
+
 pub fn bail<R, T>(msg: impl AsRef<str>, tokens: T) -> Result<R, Error>
 where
     T: Spanned,

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -9,6 +9,7 @@ func run() -> bool:
 	var ok = true
 	#ok = ok && test_missing_init()
 	ok = ok && test_to_string()
+	ok = ok && test_export()
 
 	print("[GD] ManualFfi tested (passed=", ok, ")")
 	return ok
@@ -28,6 +29,20 @@ func test_to_string() -> bool:
 	
 func test_export() -> bool:
 	var obj = HasProperty.new()
-	obj.val = 5
-	print("[GD] HasProperty's property is: ", obj.val, " and should be 5")
-	return obj.val == 5
+
+	obj.int_val = 5
+	print("[GD] HasProperty's int_val property is: ", obj.int_val, " and should be 5")
+	var int_val_correct = obj.int_val == 5
+
+	obj.string_val = "test val"
+	print("[GD] HasProperty's string_val property is: ", obj.string_val, " and should be \"test val\"")
+	var string_val_correct = obj.string_val == "test val"
+
+	var node = Node.new()
+	obj.object_val = node
+	print("[GD] HasProperty's object_val property is: ", obj.object_val, " and should be ", node)
+	var object_val_correct = obj.object_val == node
+
+	obj.free()
+
+	return int_val_correct && string_val_correct && object_val_correct

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -25,3 +25,9 @@ func test_to_string() -> bool:
 	print("to_string: ", s)
 	print("to_string: ", ffi)
 	return true
+	
+func test_export() -> bool:
+	var obj = HasProperty.new()
+	obj.val = 5
+	print("[GD] HasProperty's property is: ", obj.val, " and should be 5")
+	return obj.val == 5

--- a/itest/rust/src/export_test.rs
+++ b/itest/rust/src/export_test.rs
@@ -4,11 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::itest;
 use godot::prelude::*;
 
 pub(crate) fn run() -> bool {
-    let mut ok = true;
+    let ok = true;
     // No tests currently, tests using HasProperty are in Godot scripts.
 
     ok
@@ -17,28 +16,73 @@ pub(crate) fn run() -> bool {
 #[derive(GodotClass)]
 #[class(base=Node)]
 struct HasProperty {
-    #[export(getter = "get_val", setter = "set_val")]
-    val: i32,
     #[base]
     base: Base<Node>,
+    #[export(
+        getter = "get_int_val",
+        setter = "set_int_val",
+        variant_type = "::godot::sys::VariantType::Int"
+    )]
+    int_val: i32,
+    #[export(
+        getter = "get_string_val",
+        setter = "set_string_val",
+        variant_type = "::godot::sys::VariantType::String"
+    )]
+    string_val: GodotString,
+    #[export(
+        getter = "get_object_val",
+        setter = "set_object_val",
+        variant_type = "::godot::sys::VariantType::Object"
+    )]
+    object_val: Option<Gd<Object>>,
 }
 
 #[godot_api]
 impl HasProperty {
     #[func]
-    pub fn get_val(&self) -> i32 {
-        return self.val;
+    pub fn get_int_val(&self) -> i32 {
+        return self.int_val;
     }
 
     #[func]
-    pub fn set_val(&mut self, val: i32) {
-        self.val = val;
+    pub fn set_int_val(&mut self, val: i32) {
+        self.int_val = val;
+    }
+
+    #[func]
+    pub fn get_string_val(&self) -> GodotString {
+        return self.string_val.clone();
+    }
+
+    #[func]
+    pub fn set_string_val(&mut self, val: GodotString) {
+        self.string_val = val;
+    }
+
+    #[func]
+    pub fn get_object_val(&self) -> Variant {
+        if let Some(object_val) = self.object_val.as_ref() {
+            return object_val.to_variant();
+        } else {
+            return Variant::nil();
+        }
+    }
+
+    #[func]
+    pub fn set_object_val(&mut self, val: Gd<Object>) {
+        self.object_val = Some(val);
     }
 }
 
 #[godot_api]
 impl GodotExt for HasProperty {
     fn init(base: Base<Node>) -> Self {
-        HasProperty { val: 0, base }
+        HasProperty {
+            int_val: 0,
+            object_val: None,
+            string_val: GodotString::new(),
+            base,
+        }
     }
 }

--- a/itest/rust/src/export_test.rs
+++ b/itest/rust/src/export_test.rs
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::itest;
+use godot::prelude::*;
+
+pub(crate) fn run() -> bool {
+    let mut ok = true;
+    // No tests currently, tests using HasProperty are in Godot scripts.
+
+    ok
+}
+
+#[derive(GodotClass)]
+#[class(base=Node)]
+struct HasProperty {
+    #[export(getter = "get_val", setter = "set_val")]
+    val: i32,
+    #[base]
+    base: Base<Node>,
+}
+
+#[godot_api]
+impl HasProperty {
+    #[func]
+    pub fn get_val(&self) -> i32 {
+        return self.val;
+    }
+
+    #[func]
+    pub fn set_val(&mut self, val: i32) {
+        self.val = val;
+    }
+}
+
+#[godot_api]
+impl GodotExt for HasProperty {
+    fn init(base: Base<Node>) -> Self {
+        HasProperty { val: 0, base }
+    }
+}

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -11,6 +11,7 @@ use std::panic::UnwindSafe;
 
 mod base_test;
 mod enum_test;
+mod export_test;
 mod gdscript_ffi_test;
 mod node_test;
 mod object_test;
@@ -27,6 +28,7 @@ fn run_tests() -> bool {
     ok &= node_test::run();
     ok &= enum_test::run();
     ok &= object_test::run();
+    ok &= export_test::run();
     ok &= singleton_test::run();
     ok &= string_test::run();
     ok &= utilities_test::run();


### PR DESCRIPTION
In progress, kv maps should probably support venial::Path types in addition to literals and idents in order to make this work.