### PR TITLE
Remove "scalar-math" feature from glam to fix incompatibilities with other crates

### DIFF
--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -20,7 +20,7 @@ godot-ffi = { path = "../godot-ffi" }
 once_cell = "1.8"
 
 # See https://docs.rs/glam/latest/glam/index.html#feature-gates
-glam = { version = "0.22", features = ["debug-glam-assert", "scalar-math"] }
+glam = { version = "0.22", features = ["debug-glam-assert"] }
 
 # Reverse dev dependencies so doctests can use `godot::` prefix
 [dev-dependencies]


### PR DESCRIPTION
Removed the "scalar-math" feature from glam.

- Closes #62 