### PR TITLE
Clippy, leak detection, `#[cfg]` cleanups

### DIFF
--- a/.github/composite/godot/action.yml
+++ b/.github/composite/godot/action.yml
@@ -109,7 +109,7 @@ runs:
       run: |
         cd itest/godot
         echo "OUTCOME=itest" >> $GITHUB_ENV
-        $GODOT4_BIN --headless 2>&1 | tee >(grep "SCRIPT ERROR:" -q && {
+        $GODOT4_BIN --headless 2>&1 | tee "${{ runner.temp }}/log.txt" | tee >(grep "SCRIPT ERROR:" -q && {
         	printf "\n -- Godot engine encountered error, abort...\n";
         	pkill godot
             echo "OUTCOME=godot-runtime" >> $GITHUB_ENV
@@ -117,6 +117,14 @@ runs:
         })
         
         echo "OUTCOME=success" >> $GITHUB_ENV
+      shell: bash
+
+    - name: "Check for memory leaks"
+      run: |
+        if grep -q "ObjectDB instances leaked at exit" "${{ runner.temp }}/log.txt"; then
+          echo "OUTCOME=godot-leak" >> $GITHUB_ENV
+          exit 2
+        fi
       shell: bash
 
     - name: "Conclusion"
@@ -137,10 +145,17 @@ runs:
             exit 2
             ;;
         
+          "godot-leak")
+            echo "### :x: Memory leak" > $GITHUB_STEP_SUMMARY
+            echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
+        	echo "Integration tests cause memory leaks." >> $GITHUB_STEP_SUMMARY
+            exit 3
+            ;;
+        
           "itest")
             echo "### :x: Godot integration tests failed" > $GITHUB_STEP_SUMMARY
             echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-            exit 3
+            exit 4
             ;;
         
           "header-diff")
@@ -150,7 +165,7 @@ runs:
           *)
             echo "### :x: Unknown error occurred" > $GITHUB_STEP_SUMMARY
             echo "$GODOT_BUILT_FROM" >> $GITHUB_STEP_SUMMARY
-            exit 4
+            exit 5
             ;;
         esac
       shell: bash

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -31,13 +31,52 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+
       - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           rust: stable
           components: rustfmt
+
       - name: "Check rustfmt"
         run: cargo fmt --all -- --check
+
+
+  clippy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Install Rust"
+        uses: ./.github/composite/rust
+
+      # TODO get rid of Godot binary, once the JSON is either versioned or fetched from somewhere
+      # Replaces also backspaces on Windows, since they cause problems in Bash
+      - name: "Store variable to Godot binary"
+        run: |
+          runnerDir=$(echo "${{ runner.temp }}" | sed "s!\\\\!/!")
+          echo "RUNNER_DIR=$runnerDir" >> $GITHUB_ENV
+          echo "GODOT4_BIN=$runnerDir/godot_bin/godot.linuxbsd.editor.dev.x86_64" >> $GITHUB_ENV
+
+      #      - name: "Check cache for installed Godot version"
+      #        id: "cache-godot"
+      #        uses: actions/cache@v3
+      #        with:
+      #          path: ${{ runner.temp }}/godot_bin
+      #          key: ${{ inputs.artifact-name }}-v${{ inputs.godot-ver }}
+
+      - name: "Download Godot artifact"
+        #        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          curl https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot/master/godot-linux.zip -Lo artifact.zip
+          unzip artifact.zip -d $RUNNER_DIR/godot_bin
+
+      - name: "Prepare Godot executable"
+        run: |
+          chmod +x $GODOT4_BIN
+
+      - name: "Check clippy"
+        run: cargo clippy --features $GDEXT_FEATURES $GDEXT_CRATE_ARGS -- --cfg gdext_clippy -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented
 
 
   unit-test:
@@ -161,6 +200,7 @@ jobs:
     if: github.event_name == 'push' && success()
     needs:
       - rustfmt
+      - clippy
       - unit-test
       - itest-godot
       - license-guard

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -134,10 +134,14 @@ jobs:
         if: matrix.name == 'macos'
 
       - name: "Compile tests"
-        run: cargo test $GDEXT_CRATE_ARGS --features unit-test,$GDEXT_FEATURES --no-run
+        run: cargo test $GDEXT_CRATE_ARGS --features $GDEXT_FEATURES --no-run
+        env:
+          RUSTFLAGS: --cfg=gdext_test
 
       - name: "Test"
-        run: cargo test $GDEXT_CRATE_ARGS --features unit-test,$GDEXT_FEATURES ${{ matrix.testflags }}
+        run: cargo test $GDEXT_CRATE_ARGS --features $GDEXT_FEATURES
+        env:
+          RUSTFLAGS: --cfg=gdext_test
 
 
   itest-godot:

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -89,10 +89,14 @@ jobs:
         uses: ./.github/composite/rust
 
       - name: "Compile tests"
-        run: cargo test $GDEXT_CRATE_ARGS --features unit-test,$GDEXT_FEATURES --no-run
+        run: cargo test $GDEXT_CRATE_ARGS --features $GDEXT_FEATURES --no-run
+        env:
+          RUSTFLAGS: --cfg=gdext_test
 
       - name: "Test"
-        run: cargo test $GDEXT_CRATE_ARGS --features unit-test,$GDEXT_FEATURES ${{ matrix.testflags }}
+        run: cargo test $GDEXT_CRATE_ARGS --features $GDEXT_FEATURES
+        env:
+          RUSTFLAGS: --cfg=gdext_test
 
 
   itest-godot:

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -31,13 +31,52 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+
       - name: "Install Rust"
         uses: ./.github/composite/rust
         with:
           rust: stable
           components: rustfmt
+
       - name: "Check rustfmt"
         run: cargo fmt --all -- --check
+
+
+  clippy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: "Install Rust"
+        uses: ./.github/composite/rust
+
+      # TODO get rid of Godot binary, once the JSON is either versioned or fetched from somewhere
+      # Replaces also backspaces on Windows, since they cause problems in Bash
+      - name: "Store variable to Godot binary"
+        run: |
+          runnerDir=$(echo "${{ runner.temp }}" | sed "s!\\\\!/!")
+          echo "RUNNER_DIR=$runnerDir" >> $GITHUB_ENV
+          echo "GODOT4_BIN=$runnerDir/godot_bin/godot.linuxbsd.editor.dev.x86_64" >> $GITHUB_ENV
+
+#      - name: "Check cache for installed Godot version"
+#        id: "cache-godot"
+#        uses: actions/cache@v3
+#        with:
+#          path: ${{ runner.temp }}/godot_bin
+#          key: ${{ inputs.artifact-name }}-v${{ inputs.godot-ver }}
+
+      - name: "Download Godot artifact"
+#        if: steps.cache-godot.outputs.cache-hit != 'true'
+        run: |
+          curl https://nightly.link/Bromeon/godot4-nightly/workflows/compile-godot/master/godot-linux.zip -Lo artifact.zip
+          unzip artifact.zip -d $RUNNER_DIR/godot_bin
+
+      - name: "Prepare Godot executable"
+        run: |
+          chmod +x $GODOT4_BIN
+
+      - name: "Check clippy"
+        run: cargo clippy --features $GDEXT_FEATURES $GDEXT_CRATE_ARGS -- --cfg gdext_clippy -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented
 
 
   unit-test:
@@ -48,10 +87,6 @@ jobs:
 
       - name: "Install Rust"
         uses: ./.github/composite/rust
-
-      - name: "Install LLVM"
-        uses: ./.github/composite/llvm
-        if: matrix.name == 'macos'
 
       - name: "Compile tests"
         run: cargo test $GDEXT_CRATE_ARGS --features unit-test,$GDEXT_FEATURES --no-run

--- a/godot-codegen/input/gdextension_interface.h
+++ b/godot-codegen/input/gdextension_interface.h
@@ -503,6 +503,26 @@ typedef struct {
 	char32_t *(*string_operator_index)(GDExtensionStringPtr p_self, GDExtensionInt p_index);
 	const char32_t *(*string_operator_index_const)(GDExtensionConstStringPtr p_self, GDExtensionInt p_index);
 
+	void (*string_operator_plus_eq_string)(GDExtensionStringPtr p_self, GDExtensionConstStringPtr p_b);
+	void (*string_operator_plus_eq_char)(GDExtensionStringPtr p_self, char32_t p_b);
+	void (*string_operator_plus_eq_cstr)(GDExtensionStringPtr p_self, const char *p_b);
+	void (*string_operator_plus_eq_wcstr)(GDExtensionStringPtr p_self, const wchar_t *p_b);
+	void (*string_operator_plus_eq_c32str)(GDExtensionStringPtr p_self, const char32_t *p_b);
+
+	/*  XMLParser extra utilities */
+
+	GDExtensionInt (*xml_parser_open_buffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_buffer, size_t p_size);
+
+	/*  FileAccess extra utilities */
+
+	void (*file_access_store_buffer)(GDExtensionObjectPtr p_instance, const uint8_t *p_src, uint64_t p_length);
+	uint64_t (*file_access_get_buffer)(GDExtensionConstObjectPtr p_instance, uint8_t *p_dst, uint64_t p_length);
+
+	/*  WorkerThreadPool extra utilities */
+
+	int64_t (*worker_thread_pool_add_native_group_task)(GDExtensionObjectPtr p_instance, void (*p_func)(void *, uint32_t), void *p_userdata, int p_elements, int p_tasks, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
+	int64_t (*worker_thread_pool_add_native_task)(GDExtensionObjectPtr p_instance, void (*p_func)(void *), void *p_userdata, GDExtensionBool p_high_priority, GDExtensionConstStringPtr p_description);
+
 	/* Packed array functions */
 
 	uint8_t *(*packed_byte_array_operator_index)(GDExtensionTypePtr p_self, GDExtensionInt p_index); // p_self should be a PackedByteArray

--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -6,6 +6,7 @@
 
 // TODO remove this warning once impl is complete
 #![allow(dead_code)]
+#![allow(clippy::question_mark)] // in #[derive(DeJson)]
 
 use crate::{godot_exe, StopWatch};
 

--- a/godot-codegen/src/central_generator.rs
+++ b/godot-codegen/src/central_generator.rs
@@ -295,7 +295,7 @@ fn make_core_code(central_items: &CentralItems) -> String {
 fn make_central_items(api: &ExtensionApi, build_config: &str, ctx: &mut Context) -> CentralItems {
     let mut opaque_types = vec![];
     for class in &api.builtin_class_sizes {
-        if &class.build_configuration == build_config {
+        if class.build_configuration == build_config {
             for ClassSize { name, size } in &class.sizes {
                 opaque_types.push(make_opaque_type(name, *size));
             }
@@ -412,7 +412,7 @@ fn collect_builtin_types<'a>(
         }
 
         // Lowercase without underscore, to map SHOUTY_CASE to shoutycase
-        let normalized = shout_case.to_ascii_lowercase().replace("_", "");
+        let normalized = shout_case.to_ascii_lowercase().replace('_', "");
 
         // TODO cut down on the number of cached functions generated
         // e.g. there's no point in providing operator< for int
@@ -500,7 +500,7 @@ fn make_variant_fns(
     builtin_types: &HashMap<String, BuiltinTypeInfo>,
 ) -> (TokenStream, TokenStream) {
     let (construct_decls, construct_inits) =
-        make_construct_fns(&type_names, constructors, builtin_types);
+        make_construct_fns(type_names, constructors, builtin_types);
     let (destroy_decls, destroy_inits) = make_destroy_fns(type_names, has_destructor);
     let (op_eq_decls, op_eq_inits) = make_operator_fns(type_names, operators, "==", "EQUAL");
     let (op_lt_decls, op_lt_inits) = make_operator_fns(type_names, operators, "<", "LESS");
@@ -622,8 +622,7 @@ fn make_extra_constructors(
     let mut extra_inits = Vec::with_capacity(constructors.len() - 2);
     let variant_type = &type_names.sys_variant_type;
 
-    for i in 2..constructors.len() {
-        let ctor = &constructors[i];
+    for (i, ctor) in constructors.iter().enumerate().skip(2) {
         if let Some(args) = &ctor.arguments {
             let type_name = &type_names.snake_case;
             let ident = if args.len() == 1 && args[0].name == "from" {
@@ -688,7 +687,7 @@ fn make_operator_fns(
     sys_name: &str,
 ) -> (TokenStream, TokenStream) {
     if operators.is_none()
-        || !operators.unwrap().iter().any(|op| &op.name == json_name)
+        || !operators.unwrap().iter().any(|op| op.name == json_name)
         || is_trivial(type_names)
     {
         return (TokenStream::new(), TokenStream::new());
@@ -726,10 +725,7 @@ fn make_operator_fns(
 }
 
 fn format_load_error(ident: &impl std::fmt::Display) -> String {
-    format!(
-        "failed to load GDExtension function `{}`",
-        ident.to_string()
-    )
+    format!("failed to load GDExtension function `{ident}`")
 }
 
 /// Returns true if the type is so trivial that most of its operations are directly provided by Rust, and there is no need

--- a/godot-codegen/src/class_generator.rs
+++ b/godot-codegen/src/class_generator.rs
@@ -31,7 +31,7 @@ pub(crate) fn generate_class_files(
             continue;
         }
 
-        if special_cases::is_class_deleted(&class.name.as_str()) {
+        if special_cases::is_class_deleted(class.name.as_str()) {
             continue;
         }
 
@@ -39,7 +39,7 @@ pub(crate) fn generate_class_files(
         let file_contents = generated_class.tokens.to_string();
 
         let module_name = to_module_name(&class.name);
-        let out_path = gen_path.join(format!("{}.rs", module_name));
+        let out_path = gen_path.join(format!("{module_name}.rs"));
         std::fs::write(&out_path, file_contents).expect("failed to write class file");
         out_files.push(out_path);
 
@@ -312,25 +312,25 @@ fn is_method_excluded(method: &Method, #[allow(unused_variables)] ctx: &mut Cont
     if method
         .return_value
         .as_ref()
-        .map_or(false, |ret| is_type_excluded(&ret.type_.as_str(), ctx))
+        .map_or(false, |ret| is_type_excluded(ret.type_.as_str(), ctx))
         || method.arguments.as_ref().map_or(false, |args| {
             args.iter()
-                .any(|arg| is_type_excluded(&arg.type_.as_str(), ctx))
+                .any(|arg| is_type_excluded(arg.type_.as_str(), ctx))
         })
     {
         return true;
     }
     // -- end.
 
-    method.name.starts_with("_")
+    method.name.starts_with('_')
         || method
             .return_value
             .as_ref()
-            .map_or(false, |ret| ret.type_.contains("*"))
+            .map_or(false, |ret| ret.type_.contains('*'))
         || method
             .arguments
             .as_ref()
-            .map_or(false, |args| args.iter().any(|arg| arg.type_.contains("*")))
+            .map_or(false, |args| args.iter().any(|arg| arg.type_.contains('*')))
 }
 
 #[cfg(feature = "codegen-full")]
@@ -343,10 +343,10 @@ fn is_function_excluded(function: &UtilityFunction, ctx: &mut Context) -> bool {
     function
         .return_type
         .as_ref()
-        .map_or(false, |ret| is_type_excluded(&ret.as_str(), ctx))
+        .map_or(false, |ret| is_type_excluded(ret.as_str(), ctx))
         || function.arguments.as_ref().map_or(false, |args| {
             args.iter()
-                .any(|arg| is_type_excluded(&arg.type_.as_str(), ctx))
+                .any(|arg| is_type_excluded(arg.type_.as_str(), ctx))
         })
 }
 
@@ -460,7 +460,7 @@ pub(crate) fn make_function_definition(
 
     quote! {
         pub fn #function_name( #( #params ),* ) #return_decl {
-            let result = unsafe {
+            unsafe {
                 let __function_name = StringName::from(#function_name_str);
                 let __call_fn = sys::interface_fn!(variant_get_ptr_utility_function)(__function_name.string_sys(), #hash);
                 let __call_fn = __call_fn.unwrap_unchecked();
@@ -471,9 +471,7 @@ pub(crate) fn make_function_definition(
                 let __args_ptr = __args.as_ptr();
 
                 #call
-            };
-
-            result
+            }
         }
     }
 }
@@ -587,7 +585,7 @@ fn make_utility_return(
     let return_ty;
 
     if let Some(ret) = return_value {
-        let ty = to_rust_type(&ret, ctx);
+        let ty = to_rust_type(ret, ctx);
         return_decl = ty.return_decl();
         return_ty = Some(ty);
     } else {

--- a/godot-codegen/src/context.rs
+++ b/godot-codegen/src/context.rs
@@ -38,11 +38,11 @@ impl<'a> Context<'a> {
                 continue;
             }
 
-            println!("-- add engine class {}", class_name);
+            println!("-- add engine class {class_name}");
             ctx.engine_classes.insert(class_name);
 
             if let Some(base) = class.inherits.as_ref() {
-                println!("  -- inherits {}", base);
+                println!("  -- inherits {base}");
                 ctx.inheritance_tree
                     .insert(class_name.to_string(), base.clone());
             }
@@ -90,13 +90,10 @@ impl InheritanceTree {
     pub fn map_all_bases<T>(&self, derived: &str, apply: impl Fn(&str) -> T) -> Vec<T> {
         let mut maybe_base = derived;
         let mut result = vec![];
-        loop {
-            if let Some(base) = self.derived_to_base.get(maybe_base).map(String::as_str) {
-                result.push(apply(base));
-                maybe_base = base;
-            } else {
-                break;
-            }
+
+        while let Some(base) = self.derived_to_base.get(maybe_base).map(String::as_str) {
+            result.push(apply(base));
+            maybe_base = base;
         }
         result
     }

--- a/godot-codegen/src/godot_exe.rs
+++ b/godot-codegen/src/godot_exe.rs
@@ -11,10 +11,10 @@ use std::process::Command;
 
 /// Commands related to Godot executable
 
-const GODOT_VERSION_PATH: &'static str =
+const GODOT_VERSION_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/input/gen/godot_version.txt");
 
-const EXTENSION_API_PATH: &'static str =
+const EXTENSION_API_PATH: &str =
     concat!(env!("CARGO_MANIFEST_DIR"), "/input/gen/extension_api.json");
 
 pub fn load_extension_api_json(watch: &mut StopWatch) -> String {
@@ -35,7 +35,7 @@ pub fn load_extension_api_json(watch: &mut StopWatch) -> String {
     }
 
     let result = std::fs::read_to_string(json_path)
-        .expect(&format!("failed to open file {}", json_path.display()));
+        .unwrap_or_else(|_| panic!("failed to open file {}", json_path.display()));
     watch.record("read_json_file");
     result
 }
@@ -53,23 +53,23 @@ fn update_version_file(version: &str) {
     let version_path = Path::new(GODOT_VERSION_PATH);
     rerun_on_changed(version_path);
 
-    std::fs::write(version_path, version).expect(&format!(
-        "write Godot version to file {}",
-        version_path.display()
-    ));
+    std::fs::write(version_path, version)
+        .unwrap_or_else(|_| panic!("write Godot version to file {}", version_path.display()));
 }
 
 fn read_godot_version(godot_bin: &Path) -> String {
-    let output = Command::new(&godot_bin)
+    let output = Command::new(godot_bin)
         .arg("--version")
         .output()
-        .expect(&format!(
-            "failed to invoke Godot executable '{}'",
-            godot_bin.display()
-        ));
+        .unwrap_or_else(|_| {
+            panic!(
+                "failed to invoke Godot executable '{}'",
+                godot_bin.display()
+            )
+        });
 
     let output = String::from_utf8(output.stdout).expect("convert Godot version to UTF-8");
-    println!("Godot version: {}", output);
+    println!("Godot version: {output}");
 
     match parse_godot_version(&output) {
         Ok(parsed) => {
@@ -84,14 +84,14 @@ fn read_godot_version(godot_bin: &Path) -> String {
         }
         Err(e) => {
             // Don't treat this as fatal error
-            panic!("failed to parse Godot version '{}': {}", output, e)
+            panic!("failed to parse Godot version '{output}': {e}")
         }
     }
 }
 
 fn dump_extension_api(godot_bin: &Path, out_file: &Path) {
     let cwd = out_file.parent().unwrap();
-    std::fs::create_dir_all(cwd).expect(&format!("create directory '{}'", cwd.display()));
+    std::fs::create_dir_all(cwd).unwrap_or_else(|_| panic!("create directory '{}'", cwd.display()));
     println!("Dump extension API to dir '{}'...", cwd.display());
 
     Command::new(godot_bin)
@@ -100,17 +100,19 @@ fn dump_extension_api(godot_bin: &Path, out_file: &Path) {
         .arg("--dump-extension-api")
         .arg(cwd)
         .output()
-        .expect(&format!(
-            "failed to invoke Godot executable '{}'",
-            godot_bin.display()
-        ));
+        .unwrap_or_else(|_| {
+            panic!(
+                "failed to invoke Godot executable '{}'",
+                godot_bin.display()
+            )
+        });
 
     println!("Generated {}/extension_api.json.", cwd.display());
 }
 
 fn locate_godot_binary() -> PathBuf {
     if let Ok(string) = std::env::var("GODOT4_BIN") {
-        println!("Found GODOT4_BIN with path to executable: '{}'", string);
+        println!("Found GODOT4_BIN with path to executable: '{string}'");
         PathBuf::from(string)
     } else if let Ok(path) = which::which("godot4") {
         println!("Found 'godot4' executable in PATH: {}", path.display());

--- a/godot-codegen/src/godot_version.rs
+++ b/godot-codegen/src/godot_version.rs
@@ -33,7 +33,7 @@ pub fn parse_godot_version(version_str: &str) -> Result<GodotVersion, Box<dyn Er
         r#"(\d+)\.(\d+)(?:\.(\d+))?\.(alpha|beta|dev|stable)[0-9]*\.(?:mono\.)?(?:[a-z_]+\.([a-f0-9]+)|official)"#,
     )?;
 
-    let fail = || format!("Version substring cannot be parsed: `{}`", version_str);
+    let fail = || format!("Version substring cannot be parsed: `{version_str}`");
     let caps = regex.captures(version_str).ok_or_else(fail)?;
 
     Ok(GodotVersion {

--- a/godot-codegen/src/special_cases.rs
+++ b/godot-codegen/src/special_cases.rs
@@ -55,7 +55,7 @@ pub fn is_private(class_name: &str, method_name: &str) -> bool {
     }
 }
 
-pub fn maybe_renamed<'c, 'm>(class_name: &'c str, method_name: &'m str) -> &'m str {
+pub fn maybe_renamed<'m>(class_name: &str, method_name: &'m str) -> &'m str {
     match (class_name, method_name) {
         ("GDScript", "new") => "instantiate",
         _ => method_name,

--- a/godot-codegen/src/tests.rs
+++ b/godot-codegen/src/tests.rs
@@ -50,7 +50,7 @@ fn module_name_generator() {
     ];
     tests.iter().for_each(|(class_name, expected)| {
         let actual = to_module_name(class_name);
-        assert_eq!(*expected, actual, "Input: {}", class_name);
+        assert_eq!(*expected, actual, "Input: {class_name}");
     });
 }
 

--- a/godot-codegen/src/util.rs
+++ b/godot-codegen/src/util.rs
@@ -14,7 +14,7 @@ pub fn make_enum_definition(enum_: &dyn Enum) -> TokenStream {
     // This would allow exhaustive matches (or at least auto-completed matches + #[non_exhaustive]). But even without #[non_exhaustive],
     // this might be a forward compatibility hazard, if Godot deprecates enumerators and adds new ones with existing ords.
 
-    let enum_name = ident(&enum_.name());
+    let enum_name = ident(enum_.name());
 
     let values = enum_.values();
     let mut enumerators = Vec::with_capacity(values.len());
@@ -22,7 +22,7 @@ pub fn make_enum_definition(enum_: &dyn Enum) -> TokenStream {
     let mut unique_ords = Vec::with_capacity(values.len());
 
     for enumerator in values {
-        let name = make_enumerator_name(&enumerator.name, &enum_.name());
+        let name = make_enumerator_name(&enumerator.name, enum_.name());
         let ordinal = Literal::i32_unsuffixed(enumerator.value);
 
         enumerators.push(quote! {

--- a/godot-codegen/src/watch.rs
+++ b/godot-codegen/src/watch.rs
@@ -75,7 +75,7 @@ impl StopWatch {
 }
 
 fn log10(n: u128) -> usize {
-    std::iter::successors(Some(n), |&n| (n >= 10).then(|| n / 10)).count()
+    std::iter::successors(Some(n), |&n| (n >= 10).then_some(n / 10)).count()
 }
 
 struct Metric {

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -24,7 +24,7 @@ glam = { version = "0.22", features = ["debug-glam-assert", "scalar-math"] }
 
 # Reverse dev dependencies so doctests can use `godot::` prefix
 [dev-dependencies]
-#godot = { path = "../godot" } # when re-enabling, add unit-test feature to `godot`, or it will mess things up
+godot = { path = "../godot" } # when re-enabling, add unit-test feature to `godot`, or it will mess things up
 #godot-ffi = { path = "../godot-ffi", features = ["unit-test"] } # unit-test
 
 [build-dependencies]

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -13,7 +13,6 @@ trace = []
 codegen-fmt = ["godot-ffi/codegen-fmt"]
 codegen-full = ["godot-codegen/codegen-full"]
 convenience = []
-unit-test = ["godot-ffi/unit-test"] # If this crate is built for a downstream unit test
 
 [dependencies]
 godot-ffi = { path = "../godot-ffi" }
@@ -24,8 +23,7 @@ glam = { version = "0.22", features = ["debug-glam-assert", "scalar-math"] }
 
 # Reverse dev dependencies so doctests can use `godot::` prefix
 [dev-dependencies]
-godot = { path = "../godot" } # when re-enabling, add unit-test feature to `godot`, or it will mess things up
-#godot-ffi = { path = "../godot-ffi", features = ["unit-test"] } # unit-test
+godot = { path = "../godot" }
 
 [build-dependencies]
 godot-codegen = { path = "../godot-codegen" }

--- a/godot-core/build.rs
+++ b/godot-core/build.rs
@@ -15,6 +15,6 @@ fn main() {
 
     // Note: cannot use cfg!(test) because that isn't recognizable from build files.
     // See https://github.com/rust-lang/cargo/issues/1581, which was closed without a solution.
-    let stubs_only = cfg!(feature = "unit-test");
+    let stubs_only = cfg!(gdext_test);
     godot_codegen::generate_core_files(gen_path, stubs_only);
 }

--- a/godot-core/src/bind.rs
+++ b/godot-core/src/bind.rs
@@ -25,6 +25,7 @@ use crate::obj::GodotClass;
 /// Do not call any of these methods directly -- they are an interface to Godot. Functionality
 /// described here is available through other means (e.g. `init` via `Gd::new_default`).
 #[allow(unused_variables)]
+#[allow(clippy::unimplemented)] // TODO consider using panic! with specific message, possibly generated code
 pub trait GodotExt: crate::private::You_forgot_the_attribute__godot_api
 where
     Self: GodotClass,

--- a/godot-core/src/builtin/meta/signature.rs
+++ b/godot-core/src/builtin/meta/signature.rs
@@ -8,6 +8,7 @@ use godot_ffi as sys;
 use godot_ffi::VariantType;
 use std::fmt::Debug;
 
+#[doc(hidden)]
 pub trait SignatureTuple {
     type Params;
     type Ret;
@@ -16,7 +17,7 @@ pub trait SignatureTuple {
     fn property_info(index: i32, param_name: &str) -> PropertyInfo;
     fn param_metadata(index: i32) -> sys::GDExtensionClassMethodArgumentMetadata;
 
-    fn varcall<C: GodotClass>(
+    unsafe fn varcall<C: GodotClass>(
         instance_ptr: sys::GDExtensionClassInstancePtr,
         args_ptr: *const sys::GDExtensionConstVariantPtr,
         ret: sys::GDExtensionVariantPtr,
@@ -27,7 +28,7 @@ pub trait SignatureTuple {
 
     // Note: this method imposes extra bounds on GodotFfi, which may not be implemented for user types.
     // We could fall back to varcalls in such cases, and not require GodotFfi categorically.
-    fn ptrcall<C: GodotClass>(
+    unsafe fn ptrcall<C: GodotClass>(
         instance_ptr: sys::GDExtensionClassInstancePtr,
         args_ptr: *const sys::GDExtensionConstTypePtr,
         ret: sys::GDExtensionTypePtr,
@@ -104,7 +105,7 @@ macro_rules! impl_signature_for_tuple {
             }
 
             #[inline]
-            fn varcall<C : GodotClass>(
+            unsafe fn varcall<C : GodotClass>(
 				instance_ptr: sys::GDExtensionClassInstancePtr,
                 args_ptr: *const sys::GDExtensionConstVariantPtr,
                 ret: sys::GDExtensionVariantPtr,
@@ -136,7 +137,7 @@ macro_rules! impl_signature_for_tuple {
             }
 
             #[inline]
-            fn ptrcall<C : GodotClass>(
+            unsafe fn ptrcall<C : GodotClass>(
 				instance_ptr: sys::GDExtensionClassInstancePtr,
                 args_ptr: *const sys::GDExtensionConstTypePtr,
                 ret: sys::GDExtensionTypePtr,

--- a/godot-core/src/builtin/others.rs
+++ b/godot-core/src/builtin/others.rs
@@ -33,7 +33,7 @@ struct InnerRect {
     size: Vector2,
 }
 
-#[cfg(not(feature = "unit-test"))]
+#[cfg(not(gdext_test))]
 impl Rect2 {
     pub fn size(self) -> Vector2 {
         self.inner().size

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -128,6 +128,7 @@ macro_rules! impl_variant_traits_float {
 // General impls
 
 #[rustfmt::skip]
+#[allow(clippy::module_inception)]
 mod impls {
     use super::*;
 

--- a/godot-core/src/engine.rs
+++ b/godot-core/src/engine.rs
@@ -162,7 +162,7 @@ pub(crate) fn display_string<T: GodotClass>(
     ptr: &Gd<T>,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
-    let string: GodotString = ptr.as_object(|obj| Object::to_string(obj));
+    let string: GodotString = ptr.as_object(Object::to_string);
 
     <GodotString as std::fmt::Display>::fmt(&string, f)
 }

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -18,12 +18,13 @@ pub fn __gdext_load_library<E: ExtensionLibrary>(
 
 #[cfg(not(feature = "unit-test"))]
 #[doc(hidden)]
-pub fn __gdext_load_library<E: ExtensionLibrary>(
+// TODO consider body safe despite unsafe function, and explicitly mark unsafe {} locations
+pub unsafe fn __gdext_load_library<E: ExtensionLibrary>(
     interface: *const sys::GDExtensionInterface,
     library: sys::GDExtensionClassLibraryPtr,
     init: *mut sys::GDExtensionInitialization,
 ) -> sys::GDExtensionBool {
-    unsafe { sys::initialize(interface, library) };
+    sys::initialize(interface, library);
 
     let mut handle = InitHandle::new();
 
@@ -38,10 +39,9 @@ pub fn __gdext_load_library<E: ExtensionLibrary>(
     };
 
     let is_success = /*handle.*/success as u8;
-    unsafe {
-        *init = godot_init_params;
-        INIT_HANDLE = Some(handle);
-    }
+
+    *init = godot_init_params;
+    INIT_HANDLE = Some(handle);
 
     is_success
 }
@@ -73,6 +73,36 @@ unsafe extern "C" fn ffi_deinitialize_layer(
 #[doc(hidden)]
 pub static mut INIT_HANDLE: Option<InitHandle> = None;
 
+/// Defines the entry point for a GDExtension Rust library.
+///
+/// Every library should have exactly one implementation of this trait. It is always used in combination with the
+/// [`#[gdextension]`][gdextension] proc-macro attribute.
+///
+/// The simplest usage is as follows. This will automatically perform the necessary init and cleanup routines, and register
+/// all classes marked with `#[derive(GodotClass)]`, without needing to mention them in a central list. The order in which
+/// classes are registered is not specified.
+///
+/// ```
+/// # use godot::init::*;
+///
+/// // This is just a type tag without any functionality
+/// struct MyExtension;
+///
+/// #[gdextension]
+/// unsafe impl ExtensionLibrary for MyExtension {}
+/// ```
+///
+/// # Safety
+/// By using godot-rust, you accept the safety considerations [as outlined in the book][safety].
+/// Please make sure you fully understand the implications.
+///
+/// The library cannot enforce any safety guarantees outside Rust code, which means that **you as a user** are
+/// responsible to uphold them: namely in GDScript code or other GDExtension bindings loaded by the engine.
+/// Violating this may cause undefined behavior, even when invoking _safe_ functions.
+///
+/// [gdextension]: crate::init::gdextension
+/// [safety]: https://godot-rust.github.io/book/gdextension/safety.html
+// FIXME intra-doc link
 pub unsafe trait ExtensionLibrary {
     fn load_library(handle: &mut InitHandle) -> bool {
         handle.register_layer(InitLevel::Scene, DefaultLayer);

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -7,7 +7,7 @@
 use godot_ffi as sys;
 use std::collections::btree_map::BTreeMap;
 
-#[cfg(feature = "unit-test")]
+#[cfg(gdext_test)]
 pub fn __gdext_load_library<E: ExtensionLibrary>(
     interface: *const sys::GDExtensionInterface,
     library: sys::GDExtensionClassLibraryPtr,
@@ -16,7 +16,7 @@ pub fn __gdext_load_library<E: ExtensionLibrary>(
     sys::panic_no_godot!(__gdext_load_library)
 }
 
-#[cfg(not(feature = "unit-test"))]
+#[cfg(not(gdext_test))]
 #[doc(hidden)]
 // TODO consider body safe despite unsafe function, and explicitly mark unsafe {} locations
 pub unsafe fn __gdext_load_library<E: ExtensionLibrary>(

--- a/godot-core/src/init/mod.rs
+++ b/godot-core/src/init/mod.rs
@@ -7,7 +7,7 @@
 use godot_ffi as sys;
 use std::collections::btree_map::BTreeMap;
 
-#[cfg(any(test, feature = "unit-test"))]
+#[cfg(feature = "unit-test")]
 pub fn __gdext_load_library<E: ExtensionLibrary>(
     interface: *const sys::GDExtensionInterface,
     library: sys::GDExtensionClassLibraryPtr,
@@ -16,7 +16,7 @@ pub fn __gdext_load_library<E: ExtensionLibrary>(
     sys::panic_no_godot!(__gdext_load_library)
 }
 
-#[cfg(not(any(test, feature = "unit-test")))]
+#[cfg(not(feature = "unit-test"))]
 #[doc(hidden)]
 pub fn __gdext_load_library<E: ExtensionLibrary>(
     interface: *const sys::GDExtensionInterface,

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -43,8 +43,9 @@ pub mod engine;
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.
 #[rustfmt::skip]
-#[allow(unused_imports, dead_code, non_upper_case_globals, non_snake_case)]
-#[allow(clippy::too_many_arguments)]
+#[allow(unused_imports, dead_code, non_upper_case_globals, non_snake_case, clippy::too_many_arguments, clippy::let_and_return, clippy::new_ret_no_self)]
+#[allow(clippy::upper_case_acronyms)] // TODO remove this line once we transform names
+#[allow(clippy::wrong_self_convention)] // TODO remove once to_string is const
 mod gen;
 
 #[cfg(feature = "unit-test")]

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -5,22 +5,22 @@
  */
 
 // If running in tests, a lot of symbols are unused or panic early
-#![cfg_attr(feature = "unit-test", allow(unreachable_code, unused))]
+#![cfg_attr(gdext_test, allow(unreachable_code, unused))]
 
 // More test hacks...
 //
 // Technically, `cargo test -p godot-core` *could* be supported by this abomination:
-//   #[cfg(not(any(test, doctest, feature = "unit-test"))]
+//   #[cfg(not(any(test, doctest, gdext_test))]
 // which would be necessary because `cargo test` runs both test/doctest, and downstream crates may need the feature as
 // workaround https://github.com/rust-lang/rust/issues/59168#issuecomment-962214945. However, this *also* does not work,
 // as #[cfg(doctest)] is currently near-useless for conditional compilation: https://github.com/rust-lang/rust/issues/67295.
 // Yet even then, our compile error here is only one of many, as the compiler tries to build doctest without hitting this.
 #[cfg(all(
     test,                       // `cargo test`
-    not(feature = "unit-test"), // but forgot `--features unit-test`
-    not(gdext_clippy)           // and not `cargo clippy --cfg gdext_clippy` (this implicitly enables `test`)
+    not(gdext_test),            // but forgot `--cfg gdext_test`
+    not(gdext_clippy)           // and is not `cargo clippy --cfg gdext_clippy` (this implicitly enables `test`)
 ))]
-compile_error!("Running `cargo test` requires `--features unit-test`; `cargo clippy` requires `--cfg gdext_clippy`");
+compile_error!("Running `cargo test` requires `--cfg gdext_test`; `cargo clippy` requires `--cfg gdext_clippy`");
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -38,7 +38,7 @@ pub mod obj;
 pub use godot_ffi as sys;
 pub use registry::*;
 
-#[cfg(not(feature = "unit-test"))]
+#[cfg(not(any(gdext_test, doctest)))]
 pub mod engine;
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.
@@ -48,9 +48,11 @@ pub mod engine;
 #[allow(clippy::wrong_self_convention)] // TODO remove once to_string is const
 mod gen;
 
-#[cfg(feature = "unit-test")]
+// For some buggy reason, during doctest, the --cfg flag is not always considered, leading to monstrosities
+// such as #[cfg(not(any(gdext_test, doctest)))].
+#[cfg(any(gdext_test, doctest))]
 mod test_stubs;
-#[cfg(feature = "unit-test")]
+#[cfg(any(gdext_test, doctest))]
 pub use test_stubs::*;
 
 #[doc(hidden)]

--- a/godot-core/src/lib.rs
+++ b/godot-core/src/lib.rs
@@ -15,8 +15,12 @@
 // workaround https://github.com/rust-lang/rust/issues/59168#issuecomment-962214945. However, this *also* does not work,
 // as #[cfg(doctest)] is currently near-useless for conditional compilation: https://github.com/rust-lang/rust/issues/67295.
 // Yet even then, our compile error here is only one of many, as the compiler tries to build doctest without hitting this.
-#[cfg(all(test, not(feature = "unit-test")))]
-compile_error!("Running `cargo test` requires `--features unit-test`.");
+#[cfg(all(
+    test,                       // `cargo test`
+    not(feature = "unit-test"), // but forgot `--features unit-test`
+    not(gdext_clippy)           // and not `cargo clippy --cfg gdext_clippy` (this implicitly enables `test`)
+))]
+compile_error!("Running `cargo test` requires `--features unit-test`; `cargo clippy` requires `--cfg gdext_clippy`");
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -34,12 +38,13 @@ pub mod obj;
 pub use godot_ffi as sys;
 pub use registry::*;
 
-#[cfg(not(any(test, feature = "unit-test")))]
+#[cfg(not(feature = "unit-test"))]
 pub mod engine;
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.
 #[rustfmt::skip]
 #[allow(unused_imports, dead_code, non_upper_case_globals, non_snake_case)]
+#[allow(clippy::too_many_arguments)]
 mod gen;
 
 #[cfg(feature = "unit-test")]

--- a/godot-core/src/registry.rs
+++ b/godot-core/src/registry.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::ptr;
 
+/// Piece of information that is gathered by the self-registration ("plugin") system.
 #[derive(Debug)]
 pub struct ClassPlugin {
     pub class_name: &'static str,
@@ -39,10 +40,11 @@ pub struct ErasedRegisterFn {
 
 impl Debug for ErasedRegisterFn {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "0x{:0>16x}", self.raw as u64)
+        write!(f, "0x{:0>16x}", self.raw as usize)
     }
 }
 
+/// Represents the data part of a [`ClassPlugin`] instance.
 #[derive(Debug, Clone)]
 pub enum PluginComponent {
     /// Class definition itself, must always be available
@@ -110,6 +112,7 @@ struct ClassRegistrationInfo {
     godot_params: sys::GDExtensionClassCreationInfo,
 }
 
+/// Registers a class with static type information.
 pub fn register_class<T: GodotExt + cap::GodotInit + cap::ImplementsGodotExt>() {
     // TODO: provide overloads with only some trait impls
 
@@ -171,6 +174,7 @@ pub fn auto_register_classes() {
     out!("All classes auto-registered.");
 }
 
+/// Populate `c` with all the relevant data from `component` (depending on component type).
 fn fill_class_info(component: PluginComponent, c: &mut ClassRegistrationInfo) {
     // out!("|   reg (before):    {c:?}");
     // out!("|   comp:            {component:?}");
@@ -210,6 +214,7 @@ fn fill_class_info(component: PluginComponent, c: &mut ClassRegistrationInfo) {
     // out!();
 }
 
+/// If `src` is occupied, it moves the value into `dst`, while ensuring that no previous value is present in `dst`.
 fn fill_into<T>(dst: &mut Option<T>, src: Option<T>) {
     match (dst, src) {
         (dst @ None, src) => *dst = src,
@@ -218,6 +223,7 @@ fn fill_into<T>(dst: &mut Option<T>, src: Option<T>) {
     }
 }
 
+/// Registers a class with given the dynamic type information `info`.
 fn register_class_raw(info: ClassRegistrationInfo) {
     // First register class...
 
@@ -253,7 +259,10 @@ fn register_class_raw(info: ClassRegistrationInfo) {
     }
 }
 
-// Re-exported to crate::private
+/// Callbacks that are passed as function pointers to Godot upon class registration.
+///
+/// Re-exported to `crate::private`
+#[allow(clippy::missing_safety_doc)]
 pub mod callbacks {
     use super::*;
     use crate::bind::GodotExt;

--- a/godot-core/src/storage.rs
+++ b/godot-core/src/storage.rs
@@ -143,6 +143,9 @@ impl<T: GodotClass> Drop for InstanceStorage<T> {
 /// Interprets the opaque pointer as pointing to `InstanceStorage<T>`.
 ///
 /// Note: returns reference with unbounded lifetime; intended for local usage
+///
+/// # Safety
+/// `instance_ptr` is assumed to point to a valid instance.
 // FIXME unbounded ref AND &mut out of thin air is a huge hazard -- consider using with_storage(ptr, closure) and drop_storage(ptr)
 pub unsafe fn as_storage<'u, T: GodotClass>(
     instance_ptr: sys::GDExtensionClassInstancePtr,

--- a/godot-ffi/Cargo.toml
+++ b/godot-ffi/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["game-engines", "graphics"]
 [features]
 codegen-fmt = ["godot-codegen/codegen-fmt"]
 #codegen-full = ["godot-codegen/codegen-full"]
-unit-test = [] # If this crate is built for a downstream unit test
 
 [dependencies]
 paste = "1"

--- a/godot-ffi/build.rs
+++ b/godot-ffi/build.rs
@@ -17,7 +17,7 @@ fn main() {
 
     run_bindgen(&gen_path.join("gdextension_interface.rs"));
 
-    let stubs_only = cfg!(feature = "unit-test");
+    let stubs_only = cfg!(gdext_test);
     godot_codegen::generate_sys_files(gen_path, stubs_only);
 }
 

--- a/godot-ffi/src/global_registry.rs
+++ b/godot-ffi/src/global_registry.rs
@@ -31,7 +31,7 @@ pub struct GlobalRegistry {
 
 impl GlobalRegistry {
     pub fn c_string(&mut self, s: &str) -> *const i8 {
-        let value = CString::new(s).expect(&format!("Invalid string '{s}'"));
+        let value = CString::new(s).unwrap_or_else(|_| panic!("Invalid string '{s}'"));
 
         if let Some(existing) = self.c_strings.get(&value) {
             //println!("<<< Cache '{s}'");

--- a/godot-ffi/src/godot_ffi.rs
+++ b/godot-ffi/src/godot_ffi.rs
@@ -48,9 +48,15 @@ pub trait GodotFuncMarshal: Sized {
     type Via: Debug;
 
     /// Used for function arguments. On failure, the argument which can't be converted to Self is returned.
+    ///
+    /// # Safety
+    /// The value behind `ptr` must be the C FFI type that corresponds to `Self`.
     unsafe fn try_from_sys(ptr: sys::GDExtensionTypePtr) -> Result<Self, Self::Via>;
 
     /// Used for function return values. On failure, `self` which can't be converted to Via is returned.
+    ///
+    /// # Safety
+    /// The value behind `ptr` must be the C FFI type that corresponds to `Self`.
     unsafe fn try_write_sys(&self, dst: sys::GDExtensionTypePtr) -> Result<(), Self>;
 }
 

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -275,6 +275,7 @@ macro_rules! static_assert_eq_size {
 }
 
 /// Extract value from box before `into_inner()` is stable
+#[allow(clippy::boxed_local)] // false positive
 pub fn unbox<T>(value: Box<T>) -> T {
     // Deref-move is a Box magic feature; see https://stackoverflow.com/a/42264074
     *value

--- a/godot-ffi/src/lib.rs
+++ b/godot-ffi/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(test, allow(unused))]
 
 // Output of generated code. Mimics the file structure, symbols are re-exported.
-// Note: accessing `gen` *may* still work without explicitly specifying `unit-test` feature,
+// Note: accessing `gen` *may* still work without explicitly specifying `--cfg gdext_test` flag,
 // but stubs are generated for consistency with how godot-core depends on godot-codegen.
 #[rustfmt::skip]
 #[allow(
@@ -36,18 +36,18 @@ pub use crate::godot_ffi::{GodotFfi, GodotFuncMarshal};
 pub use gen::central::*;
 pub use gen::gdextension_interface::*; // needs `crate::`
 
-#[cfg(not(feature = "unit-test"))]
+#[cfg(not(any(gdext_test, doctest)))]
 #[doc(inline)]
 pub use real_impl::*;
 
-#[cfg(feature = "unit-test")]
+#[cfg(gdext_test)]
 #[doc(inline)]
 pub use test_impl::*;
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Real implementation, when Godot engine is running
 
-#[cfg(not(feature = "unit-test"))]
+#[cfg(not(any(gdext_test, doctest)))]
 mod real_impl {
     use super::global_registry::GlobalRegistry;
     use super::*;
@@ -171,7 +171,7 @@ mod real_impl {
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 // Stubs when in unit-test (without Godot)
 
-#[cfg(feature = "unit-test")]
+#[cfg(gdext_test)]
 mod test_impl {
     use super::gen::gdextension_interface::*;
     use super::global_registry::GlobalRegistry;
@@ -205,7 +205,7 @@ mod test_impl {
         ($name:ident) => {{
             #[allow(unreachable_code)]
             fn panic2<T, U>(t: T, u: U) -> () {
-                panic!("builtin_fn! unavailable in unit-tests; needs Godot engine");
+                panic!("builtin_fn! unavailable in unit tests; needs Godot engine");
                 ()
             }
             panic2
@@ -213,7 +213,7 @@ mod test_impl {
         ($name:ident @1) => {{
             #[allow(unreachable_code)]
             fn panic1<T>(t: T) -> () {
-                panic!("builtin_fn! unavailable in unit-tests; needs Godot engine");
+                panic!("builtin_fn! unavailable in unit tests; needs Godot engine");
                 ()
             }
             panic1
@@ -227,7 +227,7 @@ mod test_impl {
         ($symbol:expr) => {
             panic!(concat!(
                 stringify!($symbol),
-                " unavailable in unit-tests; needs Godot engine"
+                " unavailable in unit tests; needs Godot engine"
             ))
         };
     }

--- a/godot-ffi/src/plugins.rs
+++ b/godot-ffi/src/plugins.rs
@@ -28,6 +28,7 @@ macro_rules! plugin_registry {
 
 #[doc(hidden)]
 #[macro_export]
+#[allow(clippy::all)]
 #[cfg_attr(rustfmt, rustfmt::skip)] 
 // ^ skip: paste's [< >] syntax chokes fmt
 //   cfg_attr: workaround for https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997

--- a/godot-ffi/src/plugins.rs
+++ b/godot-ffi/src/plugins.rs
@@ -28,8 +28,8 @@ macro_rules! plugin_registry {
 
 #[doc(hidden)]
 #[macro_export]
-#[allow(clippy::all)]
-#[cfg_attr(rustfmt, rustfmt::skip)] 
+#[allow(clippy::deprecated_cfg_attr)]
+#[cfg_attr(rustfmt, rustfmt::skip)]
 // ^ skip: paste's [< >] syntax chokes fmt
 //   cfg_attr: workaround for https://github.com/rust-lang/rust/pull/52234#issuecomment-976702997
 macro_rules! plugin_add_inner {

--- a/godot-macros/Cargo.toml
+++ b/godot-macros/Cargo.toml
@@ -10,8 +10,9 @@ categories = ["game-engines", "graphics"]
 [lib]
 proc-macro = true
 
+# Reverse dev dependencies so doctests can use `godot::` prefix
 [dev-dependencies]
-godot = { path = "../godot" } #, features = ["unit-test"] } # doctest
+godot = { path = "../godot" }
 
 [dependencies]
 quote = "1"

--- a/godot-macros/src/derive_godot_class.rs
+++ b/godot-macros/src/derive_godot_class.rs
@@ -4,9 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::util::{
-    bail, bail_error, ensure_kv_empty, ident, parse_kv_group, path_is_single, KvMap, KvValue,
-};
+use crate::util::{bail, ensure_kv_empty, ident, parse_kv_group, path_is_single, KvMap, KvValue};
 use crate::{util, ParseResult};
 use proc_macro2::{Ident, Punct, Span, TokenStream};
 use quote::spanned::Spanned;
@@ -18,7 +16,7 @@ pub fn transform(input: TokenStream) -> ParseResult<TokenStream> {
 
     let class = decl
         .as_struct()
-        .ok_or(venial::Error::new("Not a valid struct"))?;
+        .ok_or_else(|| venial::Error::new("Not a valid struct"))?;
 
     let struct_cfg = parse_struct_attributes(class)?;
     let fields = parse_fields(class)?;
@@ -140,7 +138,7 @@ fn parse_fields(class: &Struct) -> ParseResult<Fields> {
                     is_base = true;
                     if let Some(prev_base) = base_field {
                         bail(
-                            &format!(
+                            format!(
                                 "#[base] allowed for at most 1 field, already applied to '{}'",
                                 prev_base.name
                             ),
@@ -152,7 +150,7 @@ fn parse_fields(class: &Struct) -> ParseResult<Fields> {
                     match parse_kv_group(&attr.value) {
                         Ok(export_kv) => {
                             let exported_field =
-                                ExportedField::new_from_kv(Field::new(&field), &attr, export_kv)?;
+                                ExportedField::new_from_kv(Field::new(&field), attr, export_kv)?;
                             exported_fields.push(exported_field);
                         }
                         Err(error) => {
@@ -177,7 +175,7 @@ fn parse_fields(class: &Struct) -> ParseResult<Fields> {
 }
 
 /// Parses a `#[class(...)]` attribute
-fn parse_class_attr(attributes: &Vec<Attribute>) -> ParseResult<Option<(Span, KvMap)>> {
+fn parse_class_attr(attributes: &[Attribute]) -> ParseResult<Option<(Span, KvMap)>> {
     let mut godot_attr = None;
     for attr in attributes.iter() {
         let path = &attr.path;
@@ -243,29 +241,29 @@ impl ExportedField {
 
         ensure_kv_empty(map, attr.__span())?;
 
-        return Ok(ExportedField {
+        Ok(ExportedField {
             field,
             getter,
             setter,
             variant_type,
-        });
+        })
     }
 
     fn require_key_value(map: &mut KvMap, key: &str, attr: &Attribute) -> ParseResult<String> {
         if let Some(value) = map.remove(key) {
             if let KvValue::Lit(value) = value {
-                return Ok(value);
+                Ok(value)
             } else {
-                return bail(
+                bail(
                     format!(
                         "#[export] attribute {} with a non-literal variant_type",
                         key
                     ),
                     attr,
-                )?;
+                )?
             }
         } else {
-            return bail(format!("#[export] attribute without a {}", key), attr);
+            bail(format!("#[export] attribute without a {}", key), attr)
         }
     }
 }

--- a/godot-macros/src/gdextension.rs
+++ b/godot-macros/src/gdextension.rs
@@ -38,13 +38,13 @@ pub fn transform(meta: TokenStream, input: TokenStream) -> Result<TokenStream, v
             {
                 match (k.as_str(), v) {
                     ("entry_point", KvValue::Ident(f)) => entry_point = Some(f),
-                    _ => return bail(&format!("#[gdextension]: invalid argument `{k}`"), attr),
+                    _ => return bail(format!("#[gdextension]: invalid argument `{k}`"), attr),
                 }
             }
         }
     }
 
-    let entry_point = entry_point.unwrap_or(ident("gdextension_rust_init"));
+    let entry_point = entry_point.unwrap_or_else(|| ident("gdextension_rust_init"));
     let impl_ty = &impl_decl.self_ty;
 
     Ok(quote! {

--- a/godot-macros/src/godot_api.rs
+++ b/godot-macros/src/godot_api.rs
@@ -11,7 +11,7 @@ use quote::quote;
 use venial::{AttributeValue, Declaration, Error, Function, Impl, ImplMember};
 
 // Note: keep in sync with trait GodotExt
-const VIRTUAL_METHOD_NAMES: [&'static str; 3] = ["ready", "process", "physics_process"];
+const VIRTUAL_METHOD_NAMES: [&str; 3] = ["ready", "process", "physics_process"];
 
 pub fn transform(input: TokenStream) -> Result<TokenStream, Error> {
     let input_decl = venial::parse_declaration(input)?;
@@ -126,7 +126,7 @@ fn process_godot_fns(decl: &mut Impl) -> Result<(Vec<Function>, Vec<Ident>), Err
             continue;
         };
 
-        if let Some(attr) = extract_attributes(&method)? {
+        if let Some(attr) = extract_attributes(method)? {
             // Remaining code no longer has attribute -- rest stays
             method.attributes.remove(attr.index);
 
@@ -137,22 +137,22 @@ fn process_godot_fns(decl: &mut Impl) -> Result<(Vec<Function>, Vec<Ident>), Err
                 || method.qualifiers.tk_extern.is_some()
                 || method.qualifiers.extern_abi.is_some()
             {
-                return attr.bail("fn qualifiers are not allowed", &method);
+                return attr.bail("fn qualifiers are not allowed", method);
             }
 
             if method.generic_params.is_some() {
-                return attr.bail("generic fn parameters are not supported", &method);
+                return attr.bail("generic fn parameters are not supported", method);
             }
 
             match attr.ty {
                 BoundAttrType::Func(_attr) => {
                     // Signatures are the same thing without body
-                    let sig = util::reduce_to_signature(&method);
+                    let sig = util::reduce_to_signature(method);
                     func_signatures.push(sig);
                 }
                 BoundAttrType::Signal(ref _attr_val) => {
                     if !method.params.is_empty() || method.return_ty.is_some() {
-                        return attr.bail("parameters and return types not yet supported", &method);
+                        return attr.bail("parameters and return types not yet supported", method);
                     }
 
                     signal_idents.push(method.name.clone());

--- a/godot-macros/src/itest.rs
+++ b/godot-macros/src/itest.rs
@@ -24,7 +24,7 @@ pub fn transform(input: TokenStream) -> Result<TokenStream, Error> {
         || func.where_clause.is_some()
     {
         return bail(
-            &format!("#[itest] must be of form:  fn {}() {{ ... }}", func.name),
+            format!("#[itest] must be of form:  fn {}() {{ ... }}", func.name),
             &func,
         );
     }

--- a/godot-macros/src/lib.rs
+++ b/godot-macros/src/lib.rs
@@ -31,22 +31,10 @@ pub fn itest(_meta: TokenStream, input: TokenStream) -> TokenStream {
     translate(input, itest::transform)
 }
 
-/// Defines the global entry point for the GDExtension library.
+/// Proc-macro attribute to be used in combination with the [`ExtensionLibrary`] trait.
 ///
-/// Typical usage:
-/// ```
-/// use godot::init::{gdextension, ExtensionLibrary};
-///
-/// // This is just a type tag without any functionality
-/// struct MyExtension;
-///
-/// #[gdextension]
-/// unsafe impl ExtensionLibrary for MyExtension {}
-/// ```
-///
-/// # Safety
-/// By using godot-rust, you opt-in to the library's safety requirements (to be described in detail).
-/// The library cannot enforce any guarantees outside Rust code, which means users need to adhere to certain rules for a safe usage.
+/// [`ExtensionLibrary`]: crate::init::ExtensionLibrary
+// FIXME intra-doc link
 #[proc_macro_attribute]
 pub fn gdextension(meta: TokenStream, input: TokenStream) -> TokenStream {
     translate_meta(meta, input, gdextension::transform)

--- a/godot-macros/src/util.rs
+++ b/godot-macros/src/util.rs
@@ -22,13 +22,6 @@ pub fn strlit(s: &str) -> Literal {
     Literal::string(s)
 }
 
-pub fn bail_error<T>(msg: impl AsRef<str>, tokens: T) -> Error
-where
-    T: Spanned,
-{
-    Error::new_at_span(tokens.__span(), msg.as_ref())
-}
-
 pub fn bail<R, T>(msg: impl AsRef<str>, tokens: T) -> Result<R, Error>
 where
     T: Spanned,
@@ -218,10 +211,10 @@ pub(crate) fn validate_impl(
     if let Some(expected_trait) = expected_trait {
         // impl Trait for Self -- validate Trait
         let trait_name = original_impl.trait_ty.as_ref().unwrap(); // unwrap: already checked outside
-        if !extract_typename(&trait_name).map_or(false, |seg| seg.ident == expected_trait) {
+        if !extract_typename(trait_name).map_or(false, |seg| seg.ident == expected_trait) {
             return bail(
                 format!("#[{attr}] for trait impls requires trait to be `{expected_trait}`"),
-                &original_impl,
+                original_impl,
             );
         }
     }
@@ -233,13 +226,13 @@ pub(crate) fn validate_impl(
         } else {
             bail(
                 format!("#[{attr}] for does currently not support generic arguments"),
-                &original_impl,
+                original_impl,
             )
         }
     } else {
         bail(
             format!("#[{attr}] requires Self type to be a simple path"),
-            &original_impl,
+            original_impl,
         )
     }
 }
@@ -292,8 +285,6 @@ mod tests {
         assert_eq!(attrs.len(), 1);
         let attr_value = &attrs[0].value;
         let mut parsed = parse_kv_group(attr_value).expect("parse");
-
-        dbg!(&parsed);
 
         for (key, value) in output_map {
             assert_eq!(parsed.remove(&key), Some(value));

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -15,11 +15,7 @@ trace = ["godot-core/trace"]
 
 # Private features, they are under no stability guarantee
 codegen-full = ["godot-core/codegen-full"]
-unit-test = []
 
 [dependencies]
 godot-core = { path = "../godot-core" }
 godot-macros = { path = "../godot-macros" }
-
-#[dev-dependencies]
-#godot-core = { path = "../godot-core", features = ["unit-test"] }

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -36,7 +36,7 @@ pub use godot_core::private;
 pub mod prelude {
     pub use super::bind::{godot_api, GodotClass, GodotExt};
     pub use super::builtin::*;
-    #[cfg(not(feature = "unit-test"))]
+    #[cfg(not(any(gdext_test, doctest)))]
     pub use super::engine::{
         load, try_load, utilities, AudioStreamPlayer, Camera2D, Camera3D, Input, Node, Node2D,
         Node3D, Object, PackedScene, RefCounted, Resource, SceneTree,
@@ -46,7 +46,7 @@ pub mod prelude {
     pub use super::obj::{Base, Gd, GdMut, GdRef, GodotClass, Inherits, InstanceId, Share};
 
     // Make trait methods available
-    #[cfg(not(feature = "unit-test"))]
+    #[cfg(not(any(gdext_test, doctest)))]
     pub use super::engine::NodeExt as _;
     pub use super::obj::EngineEnum as _;
 }

--- a/itest/godot/ManualFfiTests.gd
+++ b/itest/godot/ManualFfiTests.gd
@@ -44,5 +44,6 @@ func test_export() -> bool:
 	var object_val_correct = obj.object_val == node
 
 	obj.free()
+	node.free()
 
 	return int_val_correct && string_val_correct && object_val_correct

--- a/itest/rust/src/export_test.rs
+++ b/itest/rust/src/export_test.rs
@@ -7,10 +7,9 @@
 use godot::prelude::*;
 
 pub(crate) fn run() -> bool {
-    let ok = true;
     // No tests currently, tests using HasProperty are in Godot scripts.
 
-    ok
+    true
 }
 
 #[derive(GodotClass)]
@@ -42,7 +41,7 @@ struct HasProperty {
 impl HasProperty {
     #[func]
     pub fn get_int_val(&self) -> i32 {
-        return self.int_val;
+        self.int_val
     }
 
     #[func]
@@ -52,7 +51,7 @@ impl HasProperty {
 
     #[func]
     pub fn get_string_val(&self) -> GodotString {
-        return self.string_val.clone();
+        self.string_val.clone()
     }
 
     #[func]
@@ -63,9 +62,9 @@ impl HasProperty {
     #[func]
     pub fn get_object_val(&self) -> Variant {
         if let Some(object_val) = self.object_val.as_ref() {
-            return object_val.to_variant();
+            object_val.to_variant()
         } else {
-            return Variant::nil();
+            Variant::nil()
         }
     }
 

--- a/itest/rust/src/gdscript_ffi_test.rs
+++ b/itest/rust/src/gdscript_ffi_test.rs
@@ -11,6 +11,5 @@
 mod gen_ffi;
 
 pub(crate) fn run() -> bool {
-    let ok = true;
-    ok
+    true
 }

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#[cfg(test)]
+#[all(cfg(test), not(cfg(gdext_clippy)))]
 compile_error!("`cargo test` not supported for integration test -- use `cargo run`.");
 
 use godot::bind::{godot_api, GodotClass};

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-#[all(cfg(test), not(cfg(gdext_clippy)))]
+#[cfg(all(test, not(gdext_clippy)))]
 compile_error!("`cargo test` not supported for integration test -- use `cargo run`.");
 
 use godot::bind::{godot_api, GodotClass};

--- a/itest/rust/src/virtual_methods_test.rs
+++ b/itest/rust/src/virtual_methods_test.rs
@@ -54,5 +54,4 @@ pub(crate) fn run() -> bool {
 #[itest]
 fn test_to_string() {
     let _obj = Gd::<VirtualMethodTest>::new_default();
-    dbg!(_obj);
 }


### PR DESCRIPTION
Adds `cargo clippy` to CI and fixes all its complaints.
Detects whether memory leaks occur during Godot integration tests and fails CI in that case.
Fixes some `#[cfg]` mayhem.
