### PR TITLE
Implement packed arrays non-generically

### DIFF
--- a/godot-core/src/builtin/arrays.rs
+++ b/godot-core/src/builtin/arrays.rs
@@ -6,7 +6,7 @@
 
 use godot_ffi as sys;
 
-use crate::builtin::{inner, FromVariant, ToVariant, Variant, VariantConversionError};
+use crate::builtin::*;
 use crate::obj::Share;
 use std::fmt;
 use std::marker::PhantomData;
@@ -39,16 +39,6 @@ pub struct Array {
     opaque: sys::types::OpaqueArray,
 }
 
-impl_builtin_stub!(PackedByteArray, OpaquePackedByteArray);
-impl_builtin_stub!(PackedColorArray, OpaquePackedColorArray);
-impl_builtin_stub!(PackedFloat32Array, OpaquePackedFloat32Array);
-impl_builtin_stub!(PackedFloat64Array, OpaquePackedFloat64Array);
-impl_builtin_stub!(PackedInt32Array, OpaquePackedInt32Array);
-impl_builtin_stub!(PackedInt64Array, OpaquePackedInt64Array);
-impl_builtin_stub!(PackedStringArray, OpaquePackedStringArray);
-impl_builtin_stub!(PackedVector2Array, OpaquePackedVector2Array);
-impl_builtin_stub!(PackedVector3Array, OpaquePackedVector3Array);
-
 impl_builtin_froms!(Array;
     PackedByteArray => array_from_packed_byte_array,
     PackedColorArray => array_from_packed_color_array,
@@ -60,16 +50,6 @@ impl_builtin_froms!(Array;
     PackedVector2Array => array_from_packed_vector2_array,
     PackedVector3Array => array_from_packed_vector3_array,
 );
-
-impl_builtin_froms!(PackedByteArray; Array => packed_byte_array_from_array);
-impl_builtin_froms!(PackedColorArray; Array => packed_color_array_from_array);
-impl_builtin_froms!(PackedFloat32Array; Array => packed_float32_array_from_array);
-impl_builtin_froms!(PackedFloat64Array; Array => packed_float64_array_from_array);
-impl_builtin_froms!(PackedInt32Array; Array => packed_int32_array_from_array);
-impl_builtin_froms!(PackedInt64Array; Array => packed_int64_array_from_array);
-impl_builtin_froms!(PackedStringArray; Array => packed_string_array_from_array);
-impl_builtin_froms!(PackedVector2Array; Array => packed_vector2_array_from_array);
-impl_builtin_froms!(PackedVector3Array; Array => packed_vector3_array_from_array);
 
 impl Array {
     fn from_opaque(opaque: sys::types::OpaqueArray) -> Self {
@@ -604,18 +584,6 @@ impl GodotFfi for Array {
         init_fn(result.sys_mut());
         result
     }
-}
-
-fn to_i64(i: usize) -> i64 {
-    i.try_into().unwrap()
-}
-
-fn to_usize(i: i64) -> usize {
-    i.try_into().unwrap()
-}
-
-fn to_isize(i: usize) -> isize {
-    i.try_into().unwrap()
 }
 
 #[repr(C)]

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -39,6 +39,7 @@ mod arrays;
 mod color;
 mod node_path;
 mod others;
+mod packed_array;
 mod string;
 mod string_name;
 mod variant;
@@ -55,6 +56,7 @@ pub use arrays::*;
 pub use color::*;
 pub use node_path::*;
 pub use others::*;
+pub use packed_array::*;
 pub use string::*;
 pub use string_name::*;
 pub use variant::*;
@@ -71,16 +73,14 @@ pub mod inner {
     pub use crate::gen::builtin_classes::*;
 }
 
-// pub struct PackedArray<T> {
-// 	_phantom: std::marker::PhantomData<T>
-// }
-//
-// pub type PackedByteArray = PackedArray<u8>;
-// pub type PackedInt32Array = PackedArray<i32>;
-// pub type PackedInt64Array = PackedArray<i64>;
-// pub type PackedFloat32Array = PackedArray<f32>;
-// pub type PackedFloat64Array = PackedArray<f64>;
-// pub type PackedStringArray = PackedArray<GodotString>;
-// pub type PackedVector2Array = PackedArray<Vector2>;
-// pub type PackedVector3Array = PackedArray<Vector3>;
-// pub type PackedColorArray = PackedArray<Color>;
+pub(crate) fn to_i64(i: usize) -> i64 {
+    i.try_into().unwrap()
+}
+
+pub(crate) fn to_usize(i: i64) -> usize {
+    i.try_into().unwrap()
+}
+
+pub(crate) fn to_isize(i: usize) -> isize {
+    i.try_into().unwrap()
+}

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -1,0 +1,553 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use godot_ffi as sys;
+
+use crate::builtin::*;
+use std::fmt;
+use sys::types::*;
+use sys::{ffi_methods, interface_fn, GodotFfi, TagString, TagType};
+
+/// Defines and implements a single packed array type. This macro is not hygienic and is meant to
+/// be used only in the current module.
+macro_rules! impl_packed_array {
+    (
+        // Name of the type to define, e.g. `PackedByteArray`.
+        $PackedArray:ident,
+        // Type of elements contained in the array, e.g. `u8`.
+        $Element:ty,
+        // Name of wrapped opaque type, e.g. `OpaquePackedByteArray`.
+        $Opaque:ty,
+        // Name of inner type, e.g. `InnerPackedByteArray`.
+        $Inner:ident,
+        // Name of type that represents elements in function call arguments, e.g. `i64`. See
+        // `Self::into_arg()`.
+        $Arg:ty,
+        // Type that is returned from `$operator_index` and `$operator_index_const`.
+        $IndexRetType:ty,
+        // Name of default constructor function from FFI, e.g.
+        // `packed_byte_array_construct_default`.
+        $construct_default:ident,
+        // Name of copy constructor function from FFI, e.g.
+        // `packed_byte_array_construct_copy`.
+        $construct_copy:ident,
+        // Name of constructor function from `Array` from FFI, e.g. `packed_byte_array_from_array`.
+        $from_array:ident,
+        // Name of destructor function from FFI, e.g. `packed_byte_array_destroy`.
+        $destroy:ident,
+        // Name of index operator from FFI, e.g. `packed_byte_array_operator_index`.
+        $operator_index:ident,
+        // Name of const index operator from FFI, e.g. `packed_byte_array_operator_index_const`.
+        $operator_index_const:ident,
+    ) => {
+        // TODO expand type names in doc comments (use e.g. `paste` crate)
+        /// Implements Godot's `$PackedArray` type, which is an efficient array of `$Element`s.
+        ///
+        /// Note that, unlike `Array`, this type has value semantics: each copy will be independent
+        /// of the original. (Under the hood, Godot uses copy-on-write, so copies are still cheap
+        /// to make.)
+        ///
+        /// # Thread safety
+        ///
+        /// Usage is safe if the `$PackedArray` is used on a single thread only. Concurrent reads on
+        /// different threads are also safe, but any writes must be externally synchronized. The
+        /// Rust compiler will enforce this as long as you use only Rust threads, but it cannot
+        /// protect against concurrent modification on other threads (e.g. created through
+        /// GDScript).
+        #[repr(C)]
+        pub struct $PackedArray {
+            opaque: $Opaque,
+        }
+
+        impl $PackedArray {
+            fn from_opaque(opaque: $Opaque) -> Self {
+                Self { opaque }
+            }
+        }
+
+        // This impl relies on `$Inner` which is not (yet) available in unit tests
+        #[cfg(not(any(gdext_test, doctest)))]
+        impl $PackedArray {
+            /// Constructs an empty array.
+            pub fn new() -> Self {
+                Self::default()
+            }
+
+            /// Returns the number of elements in the array. Equivalent of `size()` in Godot.
+            pub fn len(&self) -> usize {
+                to_usize(self.as_inner().size())
+            }
+
+            /// Returns `true` if the array is empty.
+            pub fn is_empty(&self) -> bool {
+                self.as_inner().is_empty()
+            }
+
+            /// Converts this array to a Rust vector, making a copy of its contents.
+            pub fn to_vec(&self) -> Vec<$Element> {
+                let len = self.len();
+                let mut vec = Vec::with_capacity(len);
+                let ptr = self.ptr(0);
+                for offset in 0..to_isize(len) {
+                    // SAFETY: Packed arrays are stored contiguously in memory, so we can use
+                    // pointer arithmetic instead of going through `$operator_index_const` for
+                    // every index.
+                    // Note that we do need to use `.clone()` because `GodotString` is refcounted;
+                    // we can't just do a memcpy.
+                    let element = unsafe { (*ptr.offset(offset)).clone() };
+                    vec.push(element);
+                }
+                vec
+            }
+
+            /// Clears the array, removing all elements.
+            pub fn clear(&mut self) {
+                self.as_inner().clear();
+            }
+
+            /// Resizes the array to contain a different number of elements. If the new size is
+            /// smaller, elements are removed from the end. If the new size is larger, new elements
+            /// are set to [`Default::default()`].
+            pub fn resize(&mut self, size: usize) {
+                self.as_inner().resize(to_i64(size));
+            }
+
+            /// Returns a slice of the array, from `begin` (inclusive) to `end` (exclusive), as a
+            /// new array.
+            ///
+            /// The values of `begin` and `end` will be clamped to the array size.
+            pub fn slice(&self, begin: usize, end: usize) -> Self {
+                let len = self.len();
+                let begin = begin.min(len);
+                let end = end.min(len);
+                self.as_inner().slice(to_i64(begin), to_i64(end))
+            }
+
+            /// Returns a copy of the value at the specified index.
+            ///
+            /// # Panics
+            ///
+            /// If `index` is out of bounds.
+            pub fn get(&self, index: usize) -> $Element {
+                let ptr = self.ptr(index);
+                // SAFETY: `ptr` just verified that the index is not out of bounds.
+                unsafe { (*ptr).clone() }
+            }
+
+            /// Finds the index of an existing value in a sorted array using binary search.
+            /// Equivalent of `bsearch` in GDScript.
+            ///
+            /// If the value is not present in the array, returns the insertion index that would
+            /// maintain sorting order.
+            ///
+            /// Calling `binary_search` on an unsorted array results in unspecified behavior.
+            pub fn binary_search(&self, value: $Element) -> usize {
+                to_usize(self.as_inner().bsearch(Self::into_arg(value), true))
+            }
+
+            /// Returns the number of times a value is in the array.
+            pub fn count(&self, value: $Element) -> usize {
+                to_usize(self.as_inner().count(Self::into_arg(value)))
+            }
+
+            /// Returns `true` if the array contains the given value. Equivalent of `has` in
+            /// GDScript.
+            pub fn contains(&self, value: $Element) -> bool {
+                self.as_inner().has(Self::into_arg(value))
+            }
+
+            /// Searches the array for the first occurrence of a value and returns its index, or
+            /// `None` if not found. Starts searching at index `from`; pass `None` to search the
+            /// entire array.
+            pub fn find(&self, value: $Element, from: Option<usize>) -> Option<usize> {
+                let from = to_i64(from.unwrap_or(0));
+                let index = self.as_inner().find(Self::into_arg(value), from);
+                if index >= 0 {
+                    Some(index.try_into().unwrap())
+                } else {
+                    None
+                }
+            }
+
+            /// Searches the array backwards for the last occurrence of a value and returns its
+            /// index, or `None` if not found. Starts searching at index `from`; pass `None` to
+            /// search the entire array.
+            pub fn rfind(&self, value: $Element, from: Option<usize>) -> Option<usize> {
+                let from = from.map(to_i64).unwrap_or(-1);
+                let index = self.as_inner().rfind(Self::into_arg(value), from);
+                // It's not documented, but `rfind` returns -1 if not found.
+                if index >= 0 {
+                    Some(to_usize(index))
+                } else {
+                    None
+                }
+            }
+
+            /// Sets the value at the specified index.
+            ///
+            /// # Panics
+            ///
+            /// If `index` is out of bounds.
+            pub fn set(&mut self, index: usize, value: $Element) {
+                let ptr_mut = self.ptr_mut(index);
+                // SAFETY: `ptr_mut` just checked that the index is not out of bounds.
+                unsafe {
+                    *ptr_mut = value;
+                }
+            }
+
+            /// Appends an element to the end of the array. Equivalent of `append` and `push_back`
+            /// in GDScript.
+            pub fn push(&mut self, value: $Element) {
+                self.as_inner().push_back(Self::into_arg(value));
+            }
+
+            /// Inserts a new element at a given index in the array. The index must be valid, or at
+            /// the end of the array (`index == len()`).
+            ///
+            /// Note: On large arrays, this method is much slower than `push` as it will move all
+            /// the array's elements after the inserted element. The larger the array, the slower
+            /// `insert` will be.
+            pub fn insert(&mut self, index: usize, value: $Element) {
+                let len = self.len();
+                assert!(
+                    index <= len,
+                    "Array insertion index {index} is out of bounds: length is {len}");
+                self.as_inner().insert(to_i64(index), Self::into_arg(value));
+            }
+
+            /// Removes and returns the element at the specified index. Similar to `remove_at` in
+            /// GDScript, but also returns the removed value.
+            ///
+            /// On large arrays, this method is much slower than `pop_back` as it will move all the array's
+            /// elements after the removed element. The larger the array, the slower `remove` will be.
+            ///
+            /// # Panics
+            ///
+            /// If `index` is out of bounds.
+            // Design note: This returns the removed value instead of `()` for consistency with
+            // `Array` and with `Vec::remove`. Compared to shifting all the subsequent array
+            // elements to their new position, the overhead of retrieving this element is trivial.
+            pub fn remove(&mut self, index: usize) -> $Element {
+                self.check_bounds(index);
+                let element = self.get(index);
+                self.as_inner().remove_at(to_i64(index));
+                element
+            }
+
+            /// Assigns the given value to all elements in the array. This can be used together
+            /// with `resize` to create an array with a given size and initialized elements.
+            pub fn fill(&mut self, value: $Element) {
+                self.as_inner().fill(Self::into_arg(value));
+            }
+
+            /// Appends another array at the end of this array. Equivalent of `append_array` in
+            /// GDScript.
+            pub fn extend_array(&mut self, other: &$PackedArray) {
+                self.as_inner().append_array(other.clone());
+            }
+
+            /// Reverses the order of the elements in the array.
+            pub fn reverse(&mut self) {
+                self.as_inner().reverse();
+            }
+
+            /// Sorts the elements of the array in ascending order.
+            // Presumably, just like `Array`, this is not a stable sort so we might call it
+            // `sort_unstable`. But Packed*Array elements that compare equal are always identical,
+            // so it doesn't matter.
+            pub fn sort(&mut self) {
+                self.as_inner().sort();
+            }
+
+            /// Asserts that the given index refers to an existing element.
+            ///
+            /// # Panics
+            ///
+            /// If `index` is out of bounds.
+            fn check_bounds(&self, index: usize) {
+                let len = self.len();
+                assert!(
+                    index < len,
+                    "Array index {index} is out of bounds: length is {len}");
+            }
+
+            /// Returns a pointer to the element at the given index.
+            ///
+            /// # Panics
+            ///
+            /// If `index` is out of bounds.
+            fn ptr(&self, index: usize) -> *const $Element {
+                self.check_bounds(index);
+                // SAFETY: We just checked that the index is not out of bounds.
+                let ptr = unsafe {
+                    let item_ptr: *const $IndexRetType =
+                        (interface_fn!($operator_index_const))(self.sys(), to_i64(index));
+                    item_ptr as *const $Element
+                };
+                assert!(!ptr.is_null());
+                ptr
+            }
+
+            /// Returns a mutable pointer to the element at the given index.
+            ///
+            /// # Panics
+            ///
+            /// If `index` is out of bounds.
+            fn ptr_mut(&self, index: usize) -> *mut $Element {
+                self.check_bounds(index);
+                // SAFETY: We just checked that the index is not out of bounds.
+                let ptr = unsafe {
+                    let item_ptr: *mut $IndexRetType =
+                        (interface_fn!($operator_index))(self.sys(), to_i64(index));
+                    item_ptr as *mut $Element
+                };
+                assert!(!ptr.is_null());
+                ptr
+            }
+
+            /// Converts an `$Element` into a value that can be passed into API functions. For most
+            /// types, this is a no-op. But `u8` and `i32` are widened to `i64`, and `f32` is
+            /// widened to `f64`.
+            #[inline]
+            fn into_arg(e: $Element) -> $Arg {
+                e.into()
+            }
+
+            #[doc(hidden)]
+            pub fn as_inner(&self) -> inner::$Inner<'_> {
+                inner::$Inner::from_outer(self)
+            }
+        }
+
+        impl_builtin_traits! {
+            for $PackedArray {
+                Default => $construct_default;
+                Clone => $construct_copy;
+                Drop => $destroy;
+            }
+        }
+
+        /// Creates a `$PackedArray` from the given Rust array.
+        #[cfg(not(any(gdext_test, doctest)))]
+        impl<const N: usize> From<&[$Element; N]> for $PackedArray {
+            fn from(arr: &[$Element; N]) -> Self {
+                Self::from(&arr[..])
+            }
+        }
+
+        /// Creates a `$PackedArray` from the given slice.
+        #[cfg(not(any(gdext_test, doctest)))]
+        impl From<&[$Element]> for $PackedArray {
+            fn from(slice: &[$Element]) -> Self {
+                let mut array = Self::new();
+                let len = slice.len();
+                if len == 0 {
+                    return array;
+                }
+                array.resize(len);
+                let ptr = array.ptr_mut(0);
+                for (i, element) in slice.iter().enumerate() {
+                    // SAFETY: The array contains exactly `len` elements, stored contiguously in memory.
+                    unsafe {
+                        // `GodotString` does not implement `Copy` so we have to call `.clone()`
+                        // here.
+                        *ptr.offset(to_isize(i)) = element.clone();
+                    }
+                }
+                array
+            }
+        }
+
+        /// Creates a `$PackedArray` from an iterator.
+        #[cfg(not(any(gdext_test, doctest)))]
+        impl FromIterator<$Element> for $PackedArray {
+            fn from_iter<I: IntoIterator<Item = $Element>>(iter: I) -> Self {
+                let mut array = $PackedArray::default();
+                array.extend(iter);
+                array
+            }
+        }
+
+        /// Extends a `$PackedArray` with the contents of an iterator.
+        #[cfg(not(any(gdext_test, doctest)))]
+        impl Extend<$Element> for $PackedArray {
+            fn extend<I: IntoIterator<Item = $Element>>(&mut self, iter: I) {
+                // Unfortunately the GDExtension API does not offer the equivalent of `Vec::reserve`.
+                // Otherwise we could use it to pre-allocate based on `iter.size_hint()`.
+                //
+                // A faster implementation using `resize()` and direct pointer writes might still be
+                // possible.
+                for item in iter.into_iter() {
+                    self.push(item);
+                }
+            }
+        }
+
+        impl_builtin_froms!($PackedArray; Array => $from_array);
+
+        impl fmt::Debug for $PackedArray {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                // Going through `Variant` because there doesn't seem to be a direct way.
+                write!(f, "{:?}", self.to_variant().stringify())
+            }
+        }
+
+        impl GodotFfi for $PackedArray {
+            ffi_methods! {
+                type sys::GDExtensionTypePtr = *mut Opaque;
+                fn from_sys;
+                fn sys;
+                fn write_sys;
+            }
+
+            unsafe fn from_sys_init(init_fn: impl FnOnce(sys::GDExtensionTypePtr)) -> Self {
+                // Can't use uninitialized pointer -- Vector CoW implementation in C++ expects that
+                // on assignment, the target CoW pointer is either initialized or nullptr
+
+                let mut result = Self::default();
+                init_fn(result.sys_mut());
+                result
+            }
+
+        }
+    }
+}
+
+impl_packed_array!(
+    PackedByteArray,
+    u8,
+    OpaquePackedByteArray,
+    InnerPackedByteArray,
+    i64,
+    u8,
+    packed_byte_array_construct_default,
+    packed_byte_array_construct_copy,
+    packed_byte_array_from_array,
+    packed_byte_array_destroy,
+    packed_byte_array_operator_index,
+    packed_byte_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedInt32Array,
+    i32,
+    OpaquePackedInt32Array,
+    InnerPackedInt32Array,
+    i64,
+    i32,
+    packed_int32_array_construct_default,
+    packed_int32_array_construct_copy,
+    packed_int32_array_from_array,
+    packed_int32_array_destroy,
+    packed_int32_array_operator_index,
+    packed_int32_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedInt64Array,
+    i64,
+    OpaquePackedInt64Array,
+    InnerPackedInt64Array,
+    i64,
+    i64,
+    packed_int64_array_construct_default,
+    packed_int64_array_construct_copy,
+    packed_int64_array_from_array,
+    packed_int64_array_destroy,
+    packed_int64_array_operator_index,
+    packed_int64_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedFloat32Array,
+    f32,
+    OpaquePackedFloat32Array,
+    InnerPackedFloat32Array,
+    f64,
+    f32,
+    packed_float32_array_construct_default,
+    packed_float32_array_construct_copy,
+    packed_float32_array_from_array,
+    packed_float32_array_destroy,
+    packed_float32_array_operator_index,
+    packed_float32_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedFloat64Array,
+    f64,
+    OpaquePackedFloat64Array,
+    InnerPackedFloat64Array,
+    f64,
+    f64,
+    packed_float64_array_construct_default,
+    packed_float64_array_construct_copy,
+    packed_float64_array_from_array,
+    packed_float64_array_destroy,
+    packed_float64_array_operator_index,
+    packed_float64_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedStringArray,
+    GodotString,
+    OpaquePackedStringArray,
+    InnerPackedStringArray,
+    GodotString,
+    TagString,
+    packed_string_array_construct_default,
+    packed_string_array_construct_copy,
+    packed_string_array_from_array,
+    packed_string_array_destroy,
+    packed_string_array_operator_index,
+    packed_string_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedVector2Array,
+    Vector2,
+    OpaquePackedVector2Array,
+    InnerPackedVector2Array,
+    Vector2,
+    TagType,
+    packed_vector2_array_construct_default,
+    packed_vector2_array_construct_copy,
+    packed_vector2_array_from_array,
+    packed_vector2_array_destroy,
+    packed_vector2_array_operator_index,
+    packed_vector2_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedVector3Array,
+    Vector3,
+    OpaquePackedVector3Array,
+    InnerPackedVector3Array,
+    Vector3,
+    TagType,
+    packed_vector3_array_construct_default,
+    packed_vector3_array_construct_copy,
+    packed_vector3_array_from_array,
+    packed_vector3_array_destroy,
+    packed_vector3_array_operator_index,
+    packed_vector3_array_operator_index_const,
+);
+
+impl_packed_array!(
+    PackedColorArray,
+    Color,
+    OpaquePackedColorArray,
+    InnerPackedColorArray,
+    Color,
+    TagType,
+    packed_color_array_construct_default,
+    packed_color_array_construct_copy,
+    packed_color_array_from_array,
+    packed_color_array_destroy,
+    packed_color_array_operator_index,
+    packed_color_array_operator_index_const,
+);

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -142,7 +142,15 @@ mod impls {
     impl_variant_traits!(GodotString, string_to_variant, string_from_variant, String);
     impl_variant_traits!(StringName, string_name_to_variant, string_name_from_variant, StringName);
     impl_variant_traits!(Array, array_to_variant, array_from_variant, Array);
-
+    impl_variant_traits!(PackedByteArray, packed_byte_array_to_variant, packed_byte_array_from_variant, PackedByteArray);
+    impl_variant_traits!(PackedInt32Array, packed_int32_array_to_variant, packed_int32_array_from_variant, PackedInt32Array);
+    impl_variant_traits!(PackedInt64Array, packed_int64_array_to_variant, packed_int64_array_from_variant, PackedInt64Array);
+    impl_variant_traits!(PackedFloat32Array, packed_float32_array_to_variant, packed_float32_array_from_variant, PackedFloat32Array);
+    impl_variant_traits!(PackedFloat64Array, packed_float64_array_to_variant, packed_float64_array_from_variant, PackedFloat64Array);
+    impl_variant_traits!(PackedStringArray, packed_string_array_to_variant, packed_string_array_from_variant, PackedStringArray);
+    impl_variant_traits!(PackedVector2Array, packed_vector2_array_to_variant, packed_vector2_array_from_variant, PackedVector2Array);
+    impl_variant_traits!(PackedVector3Array, packed_vector3_array_to_variant, packed_vector3_array_from_variant, PackedVector3Array);
+    impl_variant_traits!(PackedColorArray, packed_color_array_to_variant, packed_color_array_from_variant, PackedColorArray);
 
     impl_variant_traits!(i64, int_to_variant, int_from_variant, Int, GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT64);
     impl_variant_traits_int!(i8, GDEXTENSION_METHOD_ARGUMENT_METADATA_INT_IS_INT8);

--- a/itest/rust/src/array_test.rs
+++ b/itest/rust/src/array_test.rs
@@ -28,6 +28,7 @@ pub fn run() -> bool {
     ok &= array_find();
     ok &= array_rfind();
     ok &= array_min_max();
+    ok &= array_pick_random();
     ok &= array_set();
     ok &= array_push_pop();
     ok &= array_insert();

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -20,6 +20,7 @@ mod export_test;
 mod gdscript_ffi_test;
 mod node_test;
 mod object_test;
+mod packed_array_test;
 mod singleton_test;
 mod string_test;
 mod utilities_test;
@@ -38,6 +39,7 @@ fn run_tests() -> bool {
     ok &= singleton_test::run();
     ok &= string_test::run();
     ok &= array_test::run();
+    ok &= packed_array_test::run();
     ok &= utilities_test::run();
     ok &= variant_test::run();
     ok &= virtual_methods_test::run();

--- a/itest/rust/src/packed_array_test.rs
+++ b/itest/rust/src/packed_array_test.rs
@@ -1,0 +1,185 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use crate::{expect_panic, itest};
+use godot::builtin::PackedByteArray;
+
+pub fn run() -> bool {
+    let mut ok = true;
+    ok &= packed_array_default();
+    ok &= packed_array_new();
+    ok &= packed_array_from_iterator();
+    ok &= packed_array_from();
+    ok &= packed_array_to_vec();
+    // ok &= packed_array_into_iterator();
+    ok &= packed_array_clone();
+    ok &= packed_array_slice();
+    ok &= packed_array_get();
+    ok &= packed_array_binary_search();
+    ok &= packed_array_find();
+    ok &= packed_array_rfind();
+    ok &= packed_array_set();
+    ok &= packed_array_push();
+    ok &= packed_array_insert();
+    ok &= packed_array_extend();
+    ok &= packed_array_reverse();
+    ok &= packed_array_sort();
+    ok
+}
+
+#[itest]
+fn packed_array_default() {
+    assert_eq!(PackedByteArray::default().len(), 0);
+}
+
+#[itest]
+fn packed_array_new() {
+    assert_eq!(PackedByteArray::new().len(), 0);
+}
+
+#[itest]
+fn packed_array_from_iterator() {
+    let array = PackedByteArray::from_iter([1, 2]);
+
+    assert_eq!(array.len(), 2);
+    assert_eq!(array.get(0), 1);
+    assert_eq!(array.get(1), 2);
+}
+
+#[itest]
+fn packed_array_from() {
+    let array = PackedByteArray::from(&[1, 2]);
+
+    assert_eq!(array.len(), 2);
+    assert_eq!(array.get(0), 1);
+    assert_eq!(array.get(1), 2);
+}
+
+#[itest]
+fn packed_array_to_vec() {
+    let array = PackedByteArray::from(&[1, 2]);
+    assert_eq!(array.to_vec(), vec![1, 2]);
+}
+
+// #[itest]
+// fn packed_array_into_iterator() {
+//     let array = Array::from(&[1, 2]);
+//     let mut iter = array.into_iter();
+//     assert_eq!(iter.next(), Some(1));
+//     assert_eq!(iter.next(), Some(2));
+//     assert_eq!(iter.next(), None);
+// }
+
+#[itest]
+fn packed_array_clone() {
+    let mut array = PackedByteArray::from(&[1, 2]);
+    #[allow(clippy::redundant_clone)]
+    let clone = array.clone();
+    array.set(0, 3);
+    assert_eq!(clone.get(0), 1);
+}
+
+#[itest]
+fn packed_array_slice() {
+    let array = PackedByteArray::from(&[1, 2, 3]);
+    let slice = array.slice(1, 2);
+    assert_eq!(slice.to_vec(), vec![2]);
+}
+
+#[itest]
+fn packed_array_get() {
+    let array = PackedByteArray::from(&[1, 2]);
+
+    assert_eq!(array.get(0), 1);
+    assert_eq!(array.get(1), 2);
+    expect_panic("Array index 2 out of bounds: length is 2", || {
+        array.get(2);
+    });
+}
+
+#[itest]
+fn packed_array_binary_search() {
+    let array = PackedByteArray::from(&[1, 3]);
+
+    assert_eq!(array.binary_search(0), 0);
+    assert_eq!(array.binary_search(1), 0);
+    assert_eq!(array.binary_search(2), 1);
+    assert_eq!(array.binary_search(3), 1);
+    assert_eq!(array.binary_search(4), 2);
+}
+
+#[itest]
+fn packed_array_find() {
+    let array = PackedByteArray::from(&[1, 2, 1]);
+
+    assert_eq!(array.find(0, None), None);
+    assert_eq!(array.find(1, None), Some(0));
+    assert_eq!(array.find(1, Some(1)), Some(2));
+}
+
+#[itest]
+fn packed_array_rfind() {
+    let array = PackedByteArray::from(&[1, 2, 1]);
+
+    assert_eq!(array.rfind(0, None), None);
+    assert_eq!(array.rfind(1, None), Some(2));
+    assert_eq!(array.rfind(1, Some(1)), Some(0));
+}
+
+#[itest]
+fn packed_array_set() {
+    let mut array = PackedByteArray::from(&[1, 2]);
+
+    array.set(0, 3);
+    assert_eq!(array.get(0), 3);
+
+    expect_panic("Array index 2 out of bounds: length is 2", move || {
+        array.set(2, 4);
+    });
+}
+
+#[itest]
+fn packed_array_push() {
+    let mut array = PackedByteArray::from(&[1, 2]);
+
+    array.push(3);
+
+    assert_eq!(array.len(), 3);
+    assert_eq!(array.get(2), 3);
+}
+
+#[itest]
+fn packed_array_insert() {
+    let mut array = PackedByteArray::from(&[1, 2]);
+
+    array.insert(0, 3);
+    assert_eq!(array.to_vec(), vec![3, 1, 2]);
+
+    array.insert(3, 4);
+    assert_eq!(array.to_vec(), vec![3, 1, 2, 4]);
+}
+
+#[itest]
+fn packed_array_extend() {
+    let mut array = PackedByteArray::from(&[1, 2]);
+    let other = PackedByteArray::from(&[3, 4]);
+    array.extend_array(&other);
+    assert_eq!(array.to_vec(), vec![1, 2, 3, 4]);
+}
+
+#[itest]
+fn packed_array_sort() {
+    let mut array = PackedByteArray::from(&[2, 1]);
+    array.sort();
+    assert_eq!(array.to_vec(), vec![1, 2]);
+}
+
+#[itest]
+fn packed_array_reverse() {
+    let mut array = PackedByteArray::from(&[1, 2]);
+    array.reverse();
+    assert_eq!(array.to_vec(), vec![2, 1]);
+}


### PR DESCRIPTION
The ideal is to have a `struct PackedArray<T>`, where `T` implements some `PackedArrayElement` trait. But since the autogenerated `InnerPacked*Array` types are entirely independent at the moment and don't implement a common trait, that would require indirecting every method implementation through `PackedArrayElement`, which results in mentioning each method call three times: once in `impl PackedArray<T>`, once in `PackedArrayElement` and once in `impl PackedArrayElement for T`.

So, for now, we use a big (but quite straightforward) macro to define each `Packed*Array` as a separate type.