### PR TITLE
Add basic dictionary impl

### DIFF
--- a/godot-core/src/builtin/arrays.rs
+++ b/godot-core/src/builtin/arrays.rs
@@ -565,7 +565,7 @@ impl_builtin_traits! {
     for Array {
         Default => array_construct_default;
         Drop => array_destroy;
-        Eq => array_operator_equal;
+        PartialEq => array_operator_equal;
     }
 }
 

--- a/godot-core/src/builtin/arrays.rs
+++ b/godot-core/src/builtin/arrays.rs
@@ -565,6 +565,7 @@ impl_builtin_traits! {
     for Array {
         Default => array_construct_default;
         Drop => array_destroy;
+        Eq => array_operator_equal;
     }
 }
 

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -12,9 +12,7 @@ use super::Array;
 /// Godot's `Dictionary` type.
 ///
 /// The keys and values of the array are all `Variant`, so they can all be of different types.
-///
-/// Keys are assumed to be cheap to clone, this will usually be the case especially for
-/// value types and reference counted types.
+/// Variants are designed to be generally cheap to clone.
 ///
 /// # Thread safety
 ///
@@ -34,7 +32,7 @@ impl Dictionary {
         Self::default()
     }
 
-    /// Removes all key-value pairs from the dictionary. Equivalent to `clear` in godot.
+    /// Removes all key-value pairs from the dictionary. Equivalent to `clear` in Godot.
     pub fn clear(&mut self) {
         self.as_inner().clear()
     }
@@ -46,7 +44,7 @@ impl Dictionary {
     /// To create a shallow copy, use [`duplicate_shallow()`] instead. To create a new reference to
     /// the same array data, use [`share()`].
     ///
-    /// Equivalent to `dictionary.duplicate(true)` in godot.
+    /// Equivalent to `dictionary.duplicate(true)` in Godot.
     pub fn duplicate_deep(&self) -> Self {
         self.as_inner().duplicate(true)
     }
@@ -58,14 +56,14 @@ impl Dictionary {
     /// To create a deep copy, use [`duplicate_deep()`] instead. To create a new reference to the
     /// same dictionary data, use [`share()`].
     ///
-    /// Equivalent to `dictionary.duplicate(false)` in godot.
+    /// Equivalent to `dictionary.duplicate(false)` in Godot.
     pub fn duplicate_shallow(&self) -> Self {
         self.as_inner().duplicate(false)
     }
 
     /// Removes a key from the map, and returns the value associated with
     /// the key if the key was in the dictionary.
-    pub fn remove(&mut self, key: impl ToVariant) -> Option<Variant> {
+    pub fn remove<K: ToVariant>(&mut self, key: K) -> Option<Variant> {
         let key = key.to_variant();
         let old_value = self.get(key.clone());
         self.as_inner().erase(key);
@@ -74,9 +72,9 @@ impl Dictionary {
 
     /// Returns the first key whose associated value is `value`, if one exists.
     ///
-    /// Unlike in godot, this will return `None` if the key does not exist
+    /// Unlike in Godot, this will return `None` if the key does not exist
     /// and `Some(nil)` the key is `null`.
-    pub fn find_key_by_value(&self, value: impl ToVariant) -> Option<Variant> {
+    pub fn find_key_by_value<V: ToVariant>(&self, value: V) -> Option<Variant> {
         let key = self.as_inner().find_key(value.to_variant());
 
         if !key.is_nil() || self.contains_key(key.clone()) {
@@ -89,9 +87,9 @@ impl Dictionary {
     /// Returns the value at the key in the dictionary, if there is
     /// one.
     ///
-    /// Unlike `get` in godot, this will return `None` if there is
+    /// Unlike `get` in Godot, this will return `None` if there is
     /// no value with the given key.
-    pub fn get(&self, key: impl ToVariant) -> Option<Variant> {
+    pub fn get<K: ToVariant>(&self, key: K) -> Option<Variant> {
         let key = key.to_variant();
         if !self.contains_key(key.clone()) {
             return None;
@@ -104,22 +102,22 @@ impl Dictionary {
     /// method does not let you differentiate `NIL` values stored as values from
     /// absent keys. If you need that, use `get()`.
     ///
-    /// This is equivalent to `get` in godot.
-    pub fn get_or_nil(&self, key: impl ToVariant) -> Variant {
+    /// This is equivalent to `get` in Godot.
+    pub fn get_or_nil<K: ToVariant>(&self, key: K) -> Variant {
         self.as_inner().get(key.to_variant(), Variant::nil())
     }
 
     /// Returns `true` if the dictionary contains the given key.
     ///
-    /// This is equivalent to `has` in godot.
-    pub fn contains_key(&self, key: impl ToVariant) -> bool {
+    /// This is equivalent to `has` in Godot.
+    pub fn contains_key<K: ToVariant>(&self, key: K) -> bool {
         let key = key.to_variant();
         self.as_inner().has(key)
     }
 
     /// Returns `true` if the dictionary contains all the given keys.
     ///
-    /// This is equivalent to `has_all` in godot.
+    /// This is equivalent to `has_all` in Godot.
     pub fn contains_all_keys(&self, keys: Array) -> bool {
         self.as_inner().has_all(keys)
     }
@@ -149,14 +147,14 @@ impl Dictionary {
     /// If overwrite is true, it will overwrite pre-existing keys. Otherwise
     /// it will not.
     ///
-    /// This is equivalent to `merge` in godot.
+    /// This is equivalent to `merge` in Godot.
     pub fn extend_dictionary(&mut self, other: Self, overwrite: bool) {
         self.as_inner().merge(other, overwrite)
     }
 
     /// Returns the number of entries in the dictionary.
     ///
-    /// This is equivalent to `size` in godot.
+    /// This is equivalent to `size` in Godot.
     pub fn len(&self) -> usize {
         self.as_inner().size().try_into().unwrap()
     }
@@ -164,41 +162,41 @@ impl Dictionary {
     /// Get the pointer corresponding to the given key in the dictionary,
     /// this pointer is null if there is no value at the given key.
     #[allow(dead_code)] // TODO: remove function if it turns out i'll never actually get any use out of it
-    fn get_ptr(&self, key: impl ToVariant) -> *const Variant {
+    fn get_ptr<K: ToVariant>(&self, key: K) -> *const Variant {
         let key = key.to_variant();
         unsafe {
-            (interface_fn!(dictionary_operator_index_const))(self.sys_const(), key.var_sys_const())
-                as *const Variant
+            let ptr = (interface_fn!(dictionary_operator_index_const))(
+                self.sys_const(),
+                key.var_sys_const(),
+            );
+            ptr as *const Variant
         }
     }
 
     /// Get the pointer corresponding to the given key in the dictionary,
     /// if there exists no value at the given key then a new one is created
     /// and initialized to a nil variant.
-    fn get_ptr_mut(&mut self, key: impl ToVariant) -> *mut Variant {
+    fn get_ptr_mut<K: ToVariant>(&mut self, key: K) -> *mut Variant {
         let key = key.to_variant();
         unsafe {
             let ptr =
-                (interface_fn!(dictionary_operator_index))(self.sys_mut(), key.var_sys_const())
-                    as *mut Variant;
-            // dictionary_operator_index initializes the value so it wont be null
+                (interface_fn!(dictionary_operator_index))(self.sys_mut(), key.var_sys_const());
             assert!(!ptr.is_null());
-            // i think it might be safe to turn this into a &mut Variant?
-            ptr
+            ptr as *mut Variant
         }
     }
 
     /// Insert a value at the given key, returning the value
     /// that previously was at that key if there was one.
-    pub fn insert(&mut self, key: impl ToVariant, value: impl ToVariant) -> Option<Variant> {
+    pub fn insert<K: ToVariant, V: ToVariant>(&mut self, key: K, value: V) -> Option<Variant> {
         let key = key.to_variant();
         let old_value = self.get(key.clone());
         self.set(key, value);
         old_value
     }
 
-    /// Set a key to a given value
-    pub fn set(&mut self, key: impl ToVariant, value: impl ToVariant) {
+    /// Set a key to a given value.
+    pub fn set<K: ToVariant, V: ToVariant>(&mut self, key: K, value: V) {
         let key = key.to_variant();
         unsafe {
             *self.get_ptr_mut(key) = value.to_variant();
@@ -211,16 +209,19 @@ impl Dictionary {
     }
 }
 
-/// Creates a `Dictionary` from the given `T`. Each key and value are
+/// Creates a `Dictionary` from the given `I`. Each key and value are
 /// converted to a `Variant`.
-impl<'a, 'b, K, V, T> From<T> for Dictionary
+impl<'a, 'b, K, V, I> From<I> for Dictionary
 where
-    T: IntoIterator<Item = (&'a K, &'b V)>,
+    I: IntoIterator<Item = (&'a K, &'b V)>,
     K: ToVariant + 'a,
     V: ToVariant + 'b,
 {
-    fn from(iterable: T) -> Self {
-        iterable.into_iter().map(|(key,value)| (key.to_variant(), value.to_variant())).collect()
+    fn from(iterable: I) -> Self {
+        iterable
+            .into_iter()
+            .map(|(key, value)| (key.to_variant(), value.to_variant()))
+            .collect()
     }
 }
 
@@ -263,7 +264,7 @@ impl<K: FromVariant + Eq + std::hash::Hash> TryFrom<&Dictionary> for HashSet<K> 
 /// replacing values with existing keys with new values returned
 /// from the iterator.
 impl<K: ToVariant, V: ToVariant> Extend<(K, V)> for Dictionary {
-    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+    fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         for (k, v) in iter.into_iter() {
             self.set(k.to_variant(), v.to_variant())
         }
@@ -271,11 +272,9 @@ impl<K: ToVariant, V: ToVariant> Extend<(K, V)> for Dictionary {
 }
 
 impl<K: ToVariant, V: ToVariant> FromIterator<(K, V)> for Dictionary {
-    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let mut dict = Dictionary::new();
-        for (k, v) in iter.into_iter() {
-            dict.set(k.to_variant(), v.to_variant())
-        }
+        dict.extend(iter);
         dict
     }
 }
@@ -316,13 +315,13 @@ impl Share for Dictionary {
 }
 
 /// Creates a new dictionary with the given keys and values, the syntax mirrors
-/// godot's dictionary creation syntax.
+/// Godot's dictionary creation syntax.
 ///
 /// Any value can be used as a key, but to use an expression you need to surround it
-/// in `()` or `{}`
+/// in `()` or `{}`.
 ///
 /// Example
-/// ```rust, no_run
+/// ```no_run
 /// # #[macro_use] extern crate godot_core;
 /// # fn main() {
 /// let key = "my_key";
@@ -340,9 +339,9 @@ macro_rules! dict {
         {
             let mut d = $crate::builtin::Dictionary::new();
             $(
-                // otherwise `(1 + 2): true` would complain even though you can't write
-                // 1 + 2: true
-                #[allow(unused_parens)] 
+                // `cargo check` complains that `(1 + 2): true` has unused parens, even though it's not
+                // possible to omit the parens.
+                #[allow(unused_parens)]
                 d.set($key, $value);
             )*
             d

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -1,0 +1,314 @@
+use godot_ffi as sys;
+
+use crate::builtin::{inner, FromVariant, ToVariant, Variant, VariantConversionError};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use sys::{ffi_methods, interface_fn, GodotFfi};
+use sys::types::*;
+
+use super::Array;
+
+/// Godot's `Dictionary` type.
+///
+/// The keys and values of the array are all `Variant`, so they can all be of different types.
+/// 
+/// Keys are assumed to be cheap to clone, this will usually be the case especially for 
+/// value types and reference counted types.
+///
+/// # Safety
+///
+/// TODO: I suspect it is similar to the rules for array.
+#[repr(C)]
+pub struct Dictionary {
+    opaque: OpaqueDictionary,
+}
+
+impl Dictionary {
+    fn from_opaque(opaque: OpaqueDictionary) -> Self {
+        Self { opaque }
+    }
+
+    /// Constructs an empty `Dictionary`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Removes all key-value pairs from the dictionary. Equivalent to `clear` in godot.
+    pub fn clear(&mut self) {
+        self.as_inner().clear()
+    }
+
+    /// Returns a deep copy of the dictionary. All nested array/dictionary keys and 
+    /// values are duplicated as well.
+    /// 
+    /// Equivalent to `dictionary.duplicate(true)` in godot.
+    pub fn duplicate_deep(&self) -> Self {
+        self.as_inner().duplicate(true)
+    }
+
+    /// Returns a shallow copy of the dictionary. Nested array/dictionary keys and 
+    /// values are not duplicated.
+    /// 
+    /// Equivalent to `dictionary.duplicate(false)` in godot.
+    pub fn duplicate_shallow(&self) -> Self {
+        self.as_inner().duplicate(false)
+    }
+
+    /// Removes a key from the map, and returns the value associated with
+    /// the key if the key was in the dictionary.
+    pub fn remove<K: ToVariant>(&mut self, key: K) -> Option<Variant> {
+        let key = key.to_variant();
+        let old_value = self.get(key.clone());
+        self.as_inner().erase(key);
+        old_value
+    }
+
+    /// Returns the first key whose associated value is `value`, if one exists
+    /// 
+    /// Unlike in godot, this will return `None` if the key does not exist
+    /// and `Some(nil)` the key is `null`
+    pub fn find_key(&self, value: Variant) -> Option<Variant> {
+        let key = self.as_inner().find_key(value);
+
+        if !key.is_nil() || self.contains_key(key.clone()) {
+            Some(key)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the value at the key in the dictionary, if there is
+    /// one
+    /// 
+    /// Unlike `get` in godot, this will return `None` if there is
+    /// no value with the given key. 
+    pub fn get<K: ToVariant>(&self, key: K) -> Option<Variant> {
+        let key = key.to_variant();
+        if !self.contains_key(key.clone()) {
+            return None;
+        }
+
+        Some(self.get_or_nil(key))
+    }
+
+    /// Returns the value at the key in the dictionary, or nil otherwise
+    /// 
+    /// This is equivalent to `get` in godot.
+    pub fn get_or_nil<K: ToVariant>(&self, key: K) -> Variant {
+        self.as_inner().get(key.to_variant(), Variant::nil())
+    }
+
+    /// Returns `true` if the dictionary contains the given key
+    /// 
+    /// This is equivalent to `has` in godot
+    pub fn contains_key<K: ToVariant>(&self, key: K) -> bool {
+        let key = key.to_variant();
+        self.as_inner().has(key)
+    }
+
+    /// Returns `true` if the dictionary contains all the given keys
+    /// 
+    /// This is equivalent to `has_all` in godot
+    pub fn contains_all_keys(&self, keys: Array) -> bool {
+        self.as_inner().has_all(keys)
+    }
+
+    /// Returns a 32-bit integer hash value representing the dictionary and its contents.
+    pub fn hash(&self) -> u32 {
+        self.as_inner().hash().try_into().unwrap()
+    }
+
+    /// Creates a new `Array` containing all the keys currently in the dictionary
+    pub fn keys(&self) -> Array {
+        self.as_inner().keys()
+    }
+
+    /// Creates a new `Array` containing all the values currently in the dictionary
+    pub fn values(&self) -> Array {
+        self.as_inner().values()
+    }
+
+    /// Returns true if the dictionary is empty
+    pub fn is_empty(&self) -> bool {
+        self.as_inner().is_empty()
+    }
+
+    /// Copies all keys and values from other into self.
+    /// 
+    /// If overwrite is true, it will overwrite pre-existing keys. Otherwise
+    /// it will not.
+    /// 
+    /// This is equivalent to `merge` in godot.
+    pub fn extend_dictionary(&mut self, other: Self, overwrite: bool) {
+        self.as_inner().merge(other, overwrite)
+    }
+
+    /// Returns the number of entries in the dictionary
+    /// 
+    /// This is equivalent to `size` in godot.
+    pub fn len(&self) -> usize {
+        self.as_inner().size().try_into().unwrap()
+    }
+
+    /// Get the pointer corresponding to the given key in the dictionary,
+    /// this pointer is null if there is no value at the given key.
+    pub fn get_ptr<K: ToVariant>(&self, key: K) -> *const Variant {
+        let key = key.to_variant();
+        unsafe {
+            (interface_fn!(dictionary_operator_index_const))(self.sys_const(), key.var_sys_const()) as *const Variant
+        }
+    }
+
+    /// Get the pointer corresponding to the given key in the dictionary,
+    /// if there exists no value at the given key then a new one is created
+    /// and initialized to a nil variant.
+    pub fn get_ptr_mut<K: ToVariant>(&mut self, key: K) -> *mut Variant {
+        let key = key.to_variant();
+        unsafe {
+            let ptr =
+                (interface_fn!(dictionary_operator_index))(self.sys_mut(), key.var_sys_const()) as *mut Variant;
+            // dictionary_operator_index initializes the value so it wont be null
+            assert!(!ptr.is_null());
+            // i think it might be safe to turn this into a &mut Variant?
+            ptr
+        }
+    }
+
+    /// Insert a value at the given key, returning the value
+    /// that previously was at that key if there was one.
+    pub fn insert<K: ToVariant>(&mut self, key: K, value: Variant) -> Option<Variant> {
+        let key = key.to_variant();
+        let old_value = self.remove(key.clone());
+        self.set(key, value);
+        old_value
+    }
+
+    /// Set a key to a given value
+    pub fn set<K: ToVariant>(&mut self, key: K, value: Variant) {
+        let key = key.to_variant();
+        unsafe {
+            *self.get_ptr_mut(key) = value;
+        }
+    }
+
+    /// Convert this dictionary to a strongly typed rust `HashMap`. If the conversion
+    /// fails for any key or value, an error is returned. 
+    pub fn try_to_hashmap<K: FromVariant + Eq + std::hash::Hash, V: FromVariant>(
+        &self,
+    ) -> Result<HashMap<K, V>, VariantConversionError> {
+        let mut map = HashMap::new();
+        for key in self.keys().into_iter() {
+            map.insert(key.try_to()?, self.get(key).unwrap().try_to()?);
+        }
+        Ok(map)
+    }
+
+    /// Convert the keys of this dictionary to a strongly typed rust `HashSet`. If the 
+    /// conversion fails for any key, an error is returned. 
+    pub fn try_to_hashset<K: FromVariant + Eq + std::hash::Hash>(
+        &self,
+    ) -> Result<HashSet<K>, VariantConversionError> {
+        Ok(self.keys().try_to_vec::<K>()?.into_iter().collect())
+    }
+
+    #[doc(hidden)]
+    pub fn as_inner(&self) -> inner::InnerDictionary {
+        inner::InnerDictionary::from_outer(self)
+    }
+}
+
+/// Creates a `Dictionary` from the given `HashMap`. Each key and value are 
+/// converted to a `Variant`.
+impl<K: ToVariant, V: ToVariant> From<HashMap<K, V>> for Dictionary {
+    fn from(map: HashMap<K, V>) -> Self {
+        let mut dict = Dictionary::new();
+        for (k, v) in map.into_iter() {
+            dict.insert(k.to_variant(), v.to_variant());
+        }
+        dict
+    }
+}
+
+/// Creates a `Dictionary` from the given `HashSet`. Each key is converted
+/// to a `Variant`, and the values are all `true`.
+impl<K: ToVariant> From<HashSet<K>> for Dictionary {
+    fn from(set: HashSet<K>) -> Self {
+        let mut dict = Dictionary::new();
+        for k in set.into_iter() {
+            dict.insert(k.to_variant(), true.to_variant());
+        }
+        dict
+    }
+}
+
+/// Inserts all key-values from the iterator into the dictionary,
+/// replacing values with existing keys with new values returned
+/// from the iterator.
+impl<K: ToVariant, V: ToVariant> Extend<(K, V)> for Dictionary {
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        for (k, v) in iter.into_iter() {
+            self.insert(k.to_variant(), v.to_variant());
+        }
+    }
+}
+
+impl<K: ToVariant, V: ToVariant> FromIterator<(K, V)> for Dictionary {
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let mut dict = Dictionary::new();
+        for (k, v) in iter.into_iter() {
+            dict.insert(k.to_variant(), v.to_variant());
+        }
+        dict
+    }
+}
+
+impl_builtin_traits! {
+    for Dictionary {
+        Default => dictionary_construct_default;
+        Clone => dictionary_construct_copy;
+        Drop => dictionary_destroy;
+        Eq => dictionary_operator_equal;
+    }
+}
+
+impl GodotFfi for Dictionary {
+    ffi_methods! { type sys::GDExtensionTypePtr = *mut Opaque; .. }
+}
+
+impl fmt::Debug for Dictionary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.to_variant().stringify())
+    }
+}
+
+/// Creates a new dictionary with the given keys and values, the syntax mirrors
+/// godot's dictionary creation syntax.
+/// 
+/// Currently only literal keys are supported. But any expression whose result 
+/// can be converted with `Variant::from()` may be used.
+/// 
+/// Example
+/// ```rust, no_run
+/// # #[macro_use] extern crate godot_core;
+/// # fn main() {
+/// let d = dict! {
+///     "key1": 10,
+///     "another": Variant::nil(),
+///     "true": true,
+///     "final": "final",
+/// }
+/// # }
+/// ``` 
+#[macro_export]
+macro_rules! dict {
+    () => {
+        ::godot::builtin::Dictionary::new()
+    };
+    ($($key:literal: $value:expr),+ $(,)?) => {
+        {
+            let mut d = ::godot::builtin::Dictionary::new();
+            $(d.set($key, ::godot::builtin::Variant::from($value));)*
+            d
+        }
+    };
+}

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -1,23 +1,24 @@
 use godot_ffi as sys;
 
 use crate::builtin::{inner, FromVariant, ToVariant, Variant, VariantConversionError};
+use crate::obj::Share;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use sys::{ffi_methods, interface_fn, GodotFfi};
 use sys::types::*;
+use sys::{ffi_methods, interface_fn, GodotFfi};
 
 use super::Array;
 
 /// Godot's `Dictionary` type.
 ///
 /// The keys and values of the array are all `Variant`, so they can all be of different types.
-/// 
-/// Keys are assumed to be cheap to clone, this will usually be the case especially for 
+///
+/// Keys are assumed to be cheap to clone, this will usually be the case especially for
 /// value types and reference counted types.
 ///
-/// # Safety
+/// # Thread safety
 ///
-/// TODO: I suspect it is similar to the rules for array.
+/// The same principles apply as for [`Array`]. Consult its documentation for details.
 #[repr(C)]
 pub struct Dictionary {
     opaque: OpaqueDictionary,
@@ -28,7 +29,7 @@ impl Dictionary {
         Self { opaque }
     }
 
-    /// Constructs an empty `Dictionary`
+    /// Constructs an empty `Dictionary`.
     pub fn new() -> Self {
         Self::default()
     }
@@ -38,17 +39,25 @@ impl Dictionary {
         self.as_inner().clear()
     }
 
-    /// Returns a deep copy of the dictionary. All nested array/dictionary keys and 
-    /// values are duplicated as well.
-    /// 
+    /// Returns a deep copy of the dictionary. All nested arrays and dictionaries are duplicated and
+    /// will not be shared with the original dictionary. Note that any `Object`-derived elements will
+    /// still be shallow copied.
+    ///
+    /// To create a shallow copy, use [`duplicate_shallow()`] instead. To create a new reference to
+    /// the same array data, use [`share()`].
+    ///
     /// Equivalent to `dictionary.duplicate(true)` in godot.
     pub fn duplicate_deep(&self) -> Self {
         self.as_inner().duplicate(true)
     }
 
-    /// Returns a shallow copy of the dictionary. Nested array/dictionary keys and 
-    /// values are not duplicated.
-    /// 
+    /// Returns a shallow copy of the dictionary. All dictionary keys and values are copied, but
+    /// any reference types (such as `Array`, `Dictionary` and `Object`) will still refer to the
+    /// same value.
+    ///
+    /// To create a deep copy, use [`duplicate_deep()`] instead. To create a new reference to the
+    /// same dictionary data, use [`share()`].
+    ///
     /// Equivalent to `dictionary.duplicate(false)` in godot.
     pub fn duplicate_shallow(&self) -> Self {
         self.as_inner().duplicate(false)
@@ -56,19 +65,19 @@ impl Dictionary {
 
     /// Removes a key from the map, and returns the value associated with
     /// the key if the key was in the dictionary.
-    pub fn remove<K: ToVariant>(&mut self, key: K) -> Option<Variant> {
+    pub fn remove(&mut self, key: impl ToVariant) -> Option<Variant> {
         let key = key.to_variant();
         let old_value = self.get(key.clone());
         self.as_inner().erase(key);
         old_value
     }
 
-    /// Returns the first key whose associated value is `value`, if one exists
-    /// 
+    /// Returns the first key whose associated value is `value`, if one exists.
+    ///
     /// Unlike in godot, this will return `None` if the key does not exist
-    /// and `Some(nil)` the key is `null`
-    pub fn find_key(&self, value: Variant) -> Option<Variant> {
-        let key = self.as_inner().find_key(value);
+    /// and `Some(nil)` the key is `null`.
+    pub fn find_key_by_value(&self, value: impl ToVariant) -> Option<Variant> {
+        let key = self.as_inner().find_key(value.to_variant());
 
         if !key.is_nil() || self.contains_key(key.clone()) {
             Some(key)
@@ -78,11 +87,11 @@ impl Dictionary {
     }
 
     /// Returns the value at the key in the dictionary, if there is
-    /// one
-    /// 
+    /// one.
+    ///
     /// Unlike `get` in godot, this will return `None` if there is
-    /// no value with the given key. 
-    pub fn get<K: ToVariant>(&self, key: K) -> Option<Variant> {
+    /// no value with the given key.
+    pub fn get(&self, key: impl ToVariant) -> Option<Variant> {
         let key = key.to_variant();
         if !self.contains_key(key.clone()) {
             return None;
@@ -91,24 +100,26 @@ impl Dictionary {
         Some(self.get_or_nil(key))
     }
 
-    /// Returns the value at the key in the dictionary, or nil otherwise
-    /// 
+    /// Returns the value at the key in the dictionary, or nil otherwise. This
+    /// method does not let you differentiate `NIL` values stored as values from
+    /// absent keys. If you need that, use `get()`.
+    ///
     /// This is equivalent to `get` in godot.
-    pub fn get_or_nil<K: ToVariant>(&self, key: K) -> Variant {
+    pub fn get_or_nil(&self, key: impl ToVariant) -> Variant {
         self.as_inner().get(key.to_variant(), Variant::nil())
     }
 
-    /// Returns `true` if the dictionary contains the given key
-    /// 
-    /// This is equivalent to `has` in godot
-    pub fn contains_key<K: ToVariant>(&self, key: K) -> bool {
+    /// Returns `true` if the dictionary contains the given key.
+    ///
+    /// This is equivalent to `has` in godot.
+    pub fn contains_key(&self, key: impl ToVariant) -> bool {
         let key = key.to_variant();
         self.as_inner().has(key)
     }
 
-    /// Returns `true` if the dictionary contains all the given keys
-    /// 
-    /// This is equivalent to `has_all` in godot
+    /// Returns `true` if the dictionary contains all the given keys.
+    ///
+    /// This is equivalent to `has_all` in godot.
     pub fn contains_all_keys(&self, keys: Array) -> bool {
         self.as_inner().has_all(keys)
     }
@@ -118,33 +129,33 @@ impl Dictionary {
         self.as_inner().hash().try_into().unwrap()
     }
 
-    /// Creates a new `Array` containing all the keys currently in the dictionary
+    /// Creates a new `Array` containing all the keys currently in the dictionary.
     pub fn keys(&self) -> Array {
         self.as_inner().keys()
     }
 
-    /// Creates a new `Array` containing all the values currently in the dictionary
+    /// Creates a new `Array` containing all the values currently in the dictionary.
     pub fn values(&self) -> Array {
         self.as_inner().values()
     }
 
-    /// Returns true if the dictionary is empty
+    /// Returns true if the dictionary is empty.
     pub fn is_empty(&self) -> bool {
         self.as_inner().is_empty()
     }
 
     /// Copies all keys and values from other into self.
-    /// 
+    ///
     /// If overwrite is true, it will overwrite pre-existing keys. Otherwise
     /// it will not.
-    /// 
+    ///
     /// This is equivalent to `merge` in godot.
     pub fn extend_dictionary(&mut self, other: Self, overwrite: bool) {
         self.as_inner().merge(other, overwrite)
     }
 
-    /// Returns the number of entries in the dictionary
-    /// 
+    /// Returns the number of entries in the dictionary.
+    ///
     /// This is equivalent to `size` in godot.
     pub fn len(&self) -> usize {
         self.as_inner().size().try_into().unwrap()
@@ -152,21 +163,24 @@ impl Dictionary {
 
     /// Get the pointer corresponding to the given key in the dictionary,
     /// this pointer is null if there is no value at the given key.
-    pub fn get_ptr<K: ToVariant>(&self, key: K) -> *const Variant {
+    #[allow(dead_code)] // TODO: remove function if it turns out i'll never actually get any use out of it
+    fn get_ptr(&self, key: impl ToVariant) -> *const Variant {
         let key = key.to_variant();
         unsafe {
-            (interface_fn!(dictionary_operator_index_const))(self.sys_const(), key.var_sys_const()) as *const Variant
+            (interface_fn!(dictionary_operator_index_const))(self.sys_const(), key.var_sys_const())
+                as *const Variant
         }
     }
 
     /// Get the pointer corresponding to the given key in the dictionary,
     /// if there exists no value at the given key then a new one is created
     /// and initialized to a nil variant.
-    pub fn get_ptr_mut<K: ToVariant>(&mut self, key: K) -> *mut Variant {
+    fn get_ptr_mut(&mut self, key: impl ToVariant) -> *mut Variant {
         let key = key.to_variant();
         unsafe {
             let ptr =
-                (interface_fn!(dictionary_operator_index))(self.sys_mut(), key.var_sys_const()) as *mut Variant;
+                (interface_fn!(dictionary_operator_index))(self.sys_mut(), key.var_sys_const())
+                    as *mut Variant;
             // dictionary_operator_index initializes the value so it wont be null
             assert!(!ptr.is_null());
             // i think it might be safe to turn this into a &mut Variant?
@@ -176,39 +190,19 @@ impl Dictionary {
 
     /// Insert a value at the given key, returning the value
     /// that previously was at that key if there was one.
-    pub fn insert<K: ToVariant>(&mut self, key: K, value: Variant) -> Option<Variant> {
+    pub fn insert(&mut self, key: impl ToVariant, value: impl ToVariant) -> Option<Variant> {
         let key = key.to_variant();
-        let old_value = self.remove(key.clone());
+        let old_value = self.get(key.clone());
         self.set(key, value);
         old_value
     }
 
     /// Set a key to a given value
-    pub fn set<K: ToVariant>(&mut self, key: K, value: Variant) {
+    pub fn set(&mut self, key: impl ToVariant, value: impl ToVariant) {
         let key = key.to_variant();
         unsafe {
-            *self.get_ptr_mut(key) = value;
+            *self.get_ptr_mut(key) = value.to_variant();
         }
-    }
-
-    /// Convert this dictionary to a strongly typed rust `HashMap`. If the conversion
-    /// fails for any key or value, an error is returned. 
-    pub fn try_to_hashmap<K: FromVariant + Eq + std::hash::Hash, V: FromVariant>(
-        &self,
-    ) -> Result<HashMap<K, V>, VariantConversionError> {
-        let mut map = HashMap::new();
-        for key in self.keys().into_iter() {
-            map.insert(key.try_to()?, self.get(key).unwrap().try_to()?);
-        }
-        Ok(map)
-    }
-
-    /// Convert the keys of this dictionary to a strongly typed rust `HashSet`. If the 
-    /// conversion fails for any key, an error is returned. 
-    pub fn try_to_hashset<K: FromVariant + Eq + std::hash::Hash>(
-        &self,
-    ) -> Result<HashSet<K>, VariantConversionError> {
-        Ok(self.keys().try_to_vec::<K>()?.into_iter().collect())
     }
 
     #[doc(hidden)]
@@ -217,27 +211,51 @@ impl Dictionary {
     }
 }
 
-/// Creates a `Dictionary` from the given `HashMap`. Each key and value are 
+/// Creates a `Dictionary` from the given `T`. Each key and value are
 /// converted to a `Variant`.
-impl<K: ToVariant, V: ToVariant> From<HashMap<K, V>> for Dictionary {
-    fn from(map: HashMap<K, V>) -> Self {
-        let mut dict = Dictionary::new();
-        for (k, v) in map.into_iter() {
-            dict.insert(k.to_variant(), v.to_variant());
-        }
-        dict
+impl<'a, 'b, K, V, T> From<T> for Dictionary
+where
+    T: IntoIterator<Item = (&'a K, &'b V)>,
+    K: ToVariant + 'a,
+    V: ToVariant + 'b,
+{
+    fn from(iterable: T) -> Self {
+        iterable.into_iter().map(|(key,value)| (key.to_variant(), value.to_variant())).collect()
     }
 }
 
-/// Creates a `Dictionary` from the given `HashSet`. Each key is converted
-/// to a `Variant`, and the values are all `true`.
-impl<K: ToVariant> From<HashSet<K>> for Dictionary {
-    fn from(set: HashSet<K>) -> Self {
-        let mut dict = Dictionary::new();
-        for k in set.into_iter() {
-            dict.insert(k.to_variant(), true.to_variant());
-        }
-        dict
+/// Convert this dictionary to a strongly typed rust `HashMap`. If the conversion
+/// fails for any key or value, an error is returned.
+///
+/// Will be replaced by a proper iteration implementation.
+impl<K: FromVariant + Eq + std::hash::Hash, V: FromVariant> TryFrom<&Dictionary> for HashMap<K, V> {
+    type Error = VariantConversionError;
+
+    fn try_from(dictionary: &Dictionary) -> Result<Self, Self::Error> {
+        // TODO: try to panic or something if modified while iterating
+        // Though probably better to fix when implementing iteration proper
+        dictionary
+            .keys()
+            .iter_shared()
+            .zip(dictionary.values().iter_shared())
+            .map(|(key, value)| Ok((K::try_from_variant(&key)?, V::try_from_variant(&value)?)))
+            .collect()
+    }
+}
+
+/// Convert the keys of this dictionary to a strongly typed rust `HashSet`. If the
+/// conversion fails for any key, an error is returned.
+impl<K: FromVariant + Eq + std::hash::Hash> TryFrom<&Dictionary> for HashSet<K> {
+    type Error = VariantConversionError;
+
+    fn try_from(dictionary: &Dictionary) -> Result<Self, Self::Error> {
+        // TODO: try to panic or something if modified while iterating
+        // Though probably better to fix when implementing iteration proper
+        dictionary
+            .keys()
+            .iter_shared()
+            .map(|key| K::try_from_variant(&key))
+            .collect()
     }
 }
 
@@ -247,7 +265,7 @@ impl<K: ToVariant> From<HashSet<K>> for Dictionary {
 impl<K: ToVariant, V: ToVariant> Extend<(K, V)> for Dictionary {
     fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
         for (k, v) in iter.into_iter() {
-            self.insert(k.to_variant(), v.to_variant());
+            self.set(k.to_variant(), v.to_variant())
         }
     }
 }
@@ -256,7 +274,7 @@ impl<K: ToVariant, V: ToVariant> FromIterator<(K, V)> for Dictionary {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let mut dict = Dictionary::new();
         for (k, v) in iter.into_iter() {
-            dict.insert(k.to_variant(), v.to_variant());
+            dict.set(k.to_variant(), v.to_variant())
         }
         dict
     }
@@ -265,9 +283,8 @@ impl<K: ToVariant, V: ToVariant> FromIterator<(K, V)> for Dictionary {
 impl_builtin_traits! {
     for Dictionary {
         Default => dictionary_construct_default;
-        Clone => dictionary_construct_copy;
         Drop => dictionary_destroy;
-        Eq => dictionary_operator_equal;
+        PartialEq => dictionary_operator_equal;
     }
 }
 
@@ -281,33 +298,53 @@ impl fmt::Debug for Dictionary {
     }
 }
 
+/// Creates a new reference to the data in this dictionary. Changes to the original dictionary will be
+/// reflected in the copy and vice versa.
+///
+/// To create a (mostly) independent copy instead, see [`Dictionary::duplicate_shallow()`] and
+/// [`Dictionary::duplicate_deep()`].
+impl Share for Dictionary {
+    fn share(&self) -> Self {
+        unsafe {
+            Self::from_sys_init(|self_ptr| {
+                let ctor = sys::builtin_fn!(dictionary_construct_copy);
+                let args = [self.sys_const()];
+                ctor(self_ptr, args.as_ptr());
+            })
+        }
+    }
+}
+
 /// Creates a new dictionary with the given keys and values, the syntax mirrors
 /// godot's dictionary creation syntax.
-/// 
-/// Currently only literal keys are supported. But any expression whose result 
-/// can be converted with `Variant::from()` may be used.
-/// 
+///
+/// Any value can be used as a key, but to use an expression you need to surround it
+/// in `()` or `{}`
+///
 /// Example
 /// ```rust, no_run
 /// # #[macro_use] extern crate godot_core;
 /// # fn main() {
+/// let key = "my_key";
 /// let d = dict! {
 ///     "key1": 10,
 ///     "another": Variant::nil(),
-///     "true": true,
-///     "final": "final",
+///     key: true,
+///     (1 + 2): "final",
 /// }
 /// # }
-/// ``` 
+/// ```
 #[macro_export]
 macro_rules! dict {
-    () => {
-        ::godot::builtin::Dictionary::new()
-    };
-    ($($key:literal: $value:expr),+ $(,)?) => {
+    ($($key:tt: $value:expr),* $(,)?) => {
         {
-            let mut d = ::godot::builtin::Dictionary::new();
-            $(d.set($key, ::godot::builtin::Variant::from($value));)*
+            let mut d = $crate::builtin::Dictionary::new();
+            $(
+                // otherwise `(1 + 2): true` would complain even though you can't write
+                // 1 + 2: true
+                #[allow(unused_parens)] 
+                d.set($key, $value);
+            )*
             d
         }
     };

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -37,6 +37,7 @@ mod vector_macros;
 
 mod arrays;
 mod color;
+mod dictionary;
 mod node_path;
 mod others;
 mod packed_array;
@@ -54,6 +55,7 @@ pub mod meta;
 
 pub use arrays::*;
 pub use color::*;
+pub use dictionary::*;
 pub use node_path::*;
 pub use others::*;
 pub use packed_array::*;

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -53,6 +53,8 @@ mod vector4i;
 
 pub mod meta;
 
+pub use crate::dict;
+
 pub use arrays::*;
 pub use color::*;
 pub use dictionary::*;

--- a/godot-core/src/builtin/others.rs
+++ b/godot-core/src/builtin/others.rs
@@ -25,7 +25,6 @@ impl_builtin_stub!(Projection, OpaqueProjection);
 impl_builtin_stub!(Rid, OpaqueRid);
 impl_builtin_stub!(Callable, OpaqueCallable);
 impl_builtin_stub!(Signal, OpaqueSignal);
-impl_builtin_stub!(Dictionary, OpaqueDictionary);
 
 #[repr(C)]
 struct InnerRect {

--- a/godot-core/src/builtin/string.rs
+++ b/godot-core/src/builtin/string.rs
@@ -10,6 +10,8 @@ use godot_ffi as sys;
 use sys::types::OpaqueString;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
+use super::{Variant, VariantConversionError, ToVariant, FromVariant};
+
 #[repr(C, align(8))]
 pub struct GodotString {
     opaque: OpaqueString,
@@ -144,6 +146,24 @@ impl fmt::Debug for GodotString {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = String::from(self);
         write!(f, "GodotString(\"{s}\")")
+    }
+}
+
+impl ToVariant for &str {
+    fn to_variant(&self) -> Variant {
+        crate::builtin::GodotString::from(*self).to_variant()
+    }
+}
+
+impl ToVariant for String {
+    fn to_variant(&self) -> Variant {
+        crate::builtin::GodotString::from(self).to_variant()
+    }
+}
+
+impl FromVariant for String {
+    fn try_from_variant(variant: &Variant) -> Result<Self, VariantConversionError> {
+        Ok(crate::builtin::GodotString::try_from_variant(variant)?.to_string())
     }
 }
 

--- a/godot-core/src/builtin/string.rs
+++ b/godot-core/src/builtin/string.rs
@@ -10,7 +10,7 @@ use godot_ffi as sys;
 use sys::types::OpaqueString;
 use sys::{ffi_methods, interface_fn, GodotFfi};
 
-use super::{Variant, VariantConversionError, ToVariant, FromVariant};
+use super::{FromVariant, ToVariant, Variant, VariantConversionError};
 
 #[repr(C, align(8))]
 pub struct GodotString {

--- a/godot-core/src/builtin/string.rs
+++ b/godot-core/src/builtin/string.rs
@@ -151,19 +151,19 @@ impl fmt::Debug for GodotString {
 
 impl ToVariant for &str {
     fn to_variant(&self) -> Variant {
-        crate::builtin::GodotString::from(*self).to_variant()
+        GodotString::from(*self).to_variant()
     }
 }
 
 impl ToVariant for String {
     fn to_variant(&self) -> Variant {
-        crate::builtin::GodotString::from(self).to_variant()
+        GodotString::from(self).to_variant()
     }
 }
 
 impl FromVariant for String {
     fn try_from_variant(variant: &Variant) -> Result<Self, VariantConversionError> {
-        Ok(crate::builtin::GodotString::try_from_variant(variant)?.to_string())
+        Ok(GodotString::try_from_variant(variant)?.to_string())
     }
 }
 

--- a/godot-core/src/builtin/variant/impls.rs
+++ b/godot-core/src/builtin/variant/impls.rs
@@ -133,6 +133,7 @@ mod impls {
     use super::*;
 
     impl_variant_traits!(bool, bool_to_variant, bool_from_variant, Bool);
+    impl_variant_traits!(Dictionary, dictionary_to_variant, dictionary_from_variant, Dictionary);
     impl_variant_traits!(Vector2, vector2_to_variant, vector2_from_variant, Vector2);
     impl_variant_traits!(Vector3, vector3_to_variant, vector3_from_variant, Vector3);
     impl_variant_traits!(Vector4, vector4_to_variant, vector4_from_variant, Vector4);

--- a/itest/rust/src/dictionary_test.rs
+++ b/itest/rust/src/dictionary_test.rs
@@ -1,0 +1,456 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::{HashMap, HashSet};
+
+use crate::itest;
+use godot::{
+    builtin::{Dictionary, FromVariant, ToVariant},
+    prelude::Variant,
+    private::class_macros::dict,
+};
+
+pub fn run() -> bool {
+    let mut ok = true;
+    ok &= dictionary_default();
+    ok &= dictionary_new();
+    ok &= dictionary_from_iterator();
+    ok &= dictionary_from();
+    ok &= dictionary_macro();
+    ok &= dictionary_try_to_hashmap();
+    ok &= dictionary_try_to_hashset();
+    ok &= dictionary_clone();
+    ok &= dictionary_duplicate_deep();
+    ok &= dictionary_hash();
+    ok &= dictionary_get();
+    ok &= dictionary_insert();
+    ok &= dictionary_insert_multiple();
+    ok &= dictionary_insert_long();
+    ok &= dictionary_extend();
+    ok &= dictionary_remove();
+    ok &= dictionary_clear();
+    ok &= dictionary_find_key();
+    ok &= dictionary_contains_keys();
+    ok &= dictionary_keys_values();
+    ok &= dictionary_equal();
+    ok
+}
+
+#[itest]
+fn dictionary_default() {
+    assert_eq!(Dictionary::default().len(), 0);
+}
+
+#[itest]
+fn dictionary_new() {
+    assert_eq!(Dictionary::new().len(), 0);
+}
+
+#[itest]
+fn dictionary_from_iterator() {
+    let dictionary = Dictionary::from_iter([("foo", 1), ("bar", 2)]);
+
+    assert_eq!(dictionary.len(), 2);
+    assert_eq!(
+        dictionary.get("foo".to_variant()),
+        Some(1.to_variant()),
+        "key = \"foo\""
+    );
+    assert_eq!(
+        dictionary.get("bar".to_variant()),
+        Some(2.to_variant()),
+        "key = \"bar\""
+    );
+
+    let dictionary = Dictionary::from_iter([(1, "foo"), (2, "bar")]);
+
+    assert_eq!(dictionary.len(), 2);
+    assert_eq!(
+        dictionary.get(1.to_variant()),
+        Some("foo".to_variant()),
+        "key = 1"
+    );
+    assert_eq!(
+        dictionary.get(2.to_variant()),
+        Some("bar".to_variant()),
+        "key = 2"
+    );
+}
+
+#[itest]
+fn dictionary_from() {
+    let dictionary = Dictionary::from(HashMap::from([("foo", 1), ("bar", 2)]));
+
+    assert_eq!(dictionary.len(), 2);
+    assert_eq!(
+        dictionary.get("foo".to_variant()),
+        Some(1.to_variant()),
+        "key = \"foo\""
+    );
+    assert_eq!(
+        dictionary.get("bar".to_variant()),
+        Some(2.to_variant()),
+        "key = \"bar\""
+    );
+
+    let dictionary = Dictionary::from(HashMap::from([(1, "foo"), (2, "bar")]));
+
+    assert_eq!(dictionary.len(), 2);
+    assert_eq!(
+        dictionary.get(1.to_variant()),
+        Some("foo".to_variant()),
+        "key = \"foo\""
+    );
+    assert_eq!(
+        dictionary.get(2.to_variant()),
+        Some("bar".to_variant()),
+        "key = \"bar\""
+    );
+}
+
+#[itest]
+fn dictionary_macro() {
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+        "baz": "foobar"
+    };
+
+    assert_eq!(dictionary.len(), 3);
+    assert_eq!(
+        dictionary.get("foo".to_variant()),
+        Some(0.to_variant()),
+        "key = \"foo\""
+    );
+    assert_eq!(
+        dictionary.get("bar".to_variant()),
+        Some(true.to_variant()),
+        "key = \"bar\""
+    );
+    assert_eq!(
+        dictionary.get("baz".to_variant()),
+        Some("foobar".to_variant()),
+        "key = \"baz\""
+    );
+}
+
+#[itest]
+fn dictionary_try_to_hashmap() {
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": 1,
+        "baz": 2
+    };
+
+    assert_eq!(
+        dictionary.try_to_hashmap::<String, i64>(),
+        Ok(HashMap::from([
+            ("foo".into(), 0),
+            ("bar".into(), 1),
+            ("baz".into(), 2)
+        ]))
+    );
+}
+
+#[itest]
+fn dictionary_try_to_hashset() {
+    let dictionary = dict! {
+        "foo": true,
+        "bar": true,
+        "baz": true
+    };
+
+    assert_eq!(
+        dictionary.try_to_hashset::<String>(),
+        Ok(HashSet::from(["foo".into(), "bar".into(), "baz".into()]))
+    );
+}
+
+#[itest]
+fn dictionary_clone() {
+    let subdictionary = dict! {
+        "baz": true,
+        "foobar": false
+    };
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": subdictionary.clone()
+    };
+    #[allow(clippy::redundant_clone)]
+    let clone = dictionary.clone();
+    Dictionary::try_from_variant(&clone.get("bar".to_variant()).unwrap())
+        .unwrap()
+        .insert("final".to_variant(), 4.to_variant());
+    assert_eq!(
+        subdictionary.get("final".to_variant()),
+        Some(4.to_variant())
+    );
+}
+
+#[itest]
+fn dictionary_hash() {
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+        "baz": "foobar"
+    };
+    dictionary.hash();
+}
+
+#[itest]
+fn dictionary_duplicate_deep() {
+    let subdictionary = dict! {
+        "baz": true,
+        "foobar": false
+    };
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": subdictionary.clone()
+    };
+    let clone = dictionary.duplicate_deep();
+    Dictionary::try_from_variant(&clone.get("bar".to_variant()).unwrap())
+        .unwrap()
+        .insert("baz".to_variant(), 4.to_variant());
+    assert_eq!(
+        subdictionary.get("baz".to_variant()),
+        Some(true.to_variant()),
+        "key = \"baz\""
+    );
+}
+
+#[itest]
+fn dictionary_duplicate_shallow() {
+    let subdictionary = dict! {
+        "baz": true,
+        "foobar": false
+    };
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": subdictionary.clone()
+    };
+    let mut clone = dictionary.duplicate_shallow();
+    Dictionary::try_from_variant(&clone.get("bar".to_variant()).unwrap())
+        .unwrap()
+        .insert("baz".to_variant(), 4.to_variant());
+    assert_eq!(
+        subdictionary.get("baz".to_variant()),
+        Some(4.to_variant()),
+        "key = \"baz\""
+    );
+    clone.insert("foo", false.to_variant());
+    assert_eq!(dictionary.get("foo"), Some(0.to_variant()));
+    assert_eq!(clone.get("foo"), Some(false.to_variant()));
+}
+
+#[itest]
+fn dictionary_get() {
+    let mut dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+        "baz": "foobar",
+        "nil": Variant::nil(),
+    };
+
+    dictionary.insert("baz".to_variant(), "foobar".to_variant());
+
+    assert_eq!(
+        dictionary.get("foo".to_variant()),
+        Some(0.to_variant()),
+        "key = \"foo\""
+    );
+    assert_eq!(
+        dictionary.get("bar".to_variant()),
+        Some(true.to_variant()),
+        "key = \"bar\""
+    );
+    assert_eq!(
+        dictionary.get("baz".to_variant()),
+        Some("foobar".to_variant())
+    );
+    assert_eq!(
+        dictionary.get("nil".to_variant()),
+        Some(Variant::nil()),
+        "key = \"nil\""
+    );
+    assert_eq!(
+        dictionary.get("missing".to_variant()),
+        None,
+        "key = \"missing\""
+    );
+    assert_eq!(
+        dictionary.get_or_nil("nil".to_variant()),
+        Variant::nil(),
+        "key = \"nil\""
+    );
+    assert_eq!(
+        dictionary.get_or_nil("missing".to_variant()),
+        Variant::nil(),
+        "key = \"missing\""
+    );
+    assert_eq!(
+        dictionary.get("foobar".to_variant()),
+        None,
+        "key = \"foobar\""
+    );
+}
+
+#[itest]
+fn dictionary_insert() {
+    let mut dictionary = dict! {
+        "foo": 0,
+        "bar": 1,
+    };
+
+    assert_eq!(
+        dictionary.insert("bar".to_variant(), 2.to_variant()),
+        Some(1.to_variant())
+    );
+    assert_eq!(
+        dictionary.try_to_hashmap::<String, i64>().unwrap(),
+        HashMap::from([("foo".into(), 0), ("bar".into(), 2)])
+    );
+    assert_eq!(dictionary.insert("baz".to_variant(), 3.to_variant()), None);
+    assert_eq!(
+        dictionary.try_to_hashmap::<String, i64>().unwrap(),
+        HashMap::from([("foo".into(), 0), ("bar".into(), 2), ("baz".into(), 3)])
+    );
+}
+
+#[itest]
+fn dictionary_insert_multiple() {
+    let mut dictionary = dict! {};
+    assert!(dictionary.is_empty());
+
+    dictionary.insert(1.to_variant(), true.to_variant());
+    assert_eq!(dictionary.get(1.to_variant()), Some(true.to_variant()));
+
+    let mut other = dict! {};
+    assert!(other.is_empty());
+
+    other.insert(1.to_variant(), 2.to_variant());
+    assert_eq!(other.get(1.to_variant()), Some(2.to_variant()));
+}
+#[itest]
+fn dictionary_insert_long() {
+    let mut dictionary = dict! {};
+    let old = dictionary.insert(
+        "abcdefghijklmnopqrstuvwxyz",
+        "zabcdefghijklmnopqrstuvwxy".to_variant(),
+    );
+    assert_eq!(old, None);
+    assert_eq!(
+        dictionary.get("abcdefghijklmnopqrstuvwxyz"),
+        Some("zabcdefghijklmnopqrstuvwxy".to_variant())
+    );
+}
+
+#[itest]
+fn dictionary_extend() {
+    let mut dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+    };
+    assert_eq!(dictionary.get("foo".to_variant()), Some(0.to_variant()));
+    let other = dict! {
+        "bar": "new",
+        "baz": Variant::nil(),
+    };
+    dictionary.extend_dictionary(other, false);
+    assert_eq!(dictionary.get("bar".to_variant()), Some(true.to_variant()));
+    assert_eq!(dictionary.get("baz".to_variant()), Some(Variant::nil()));
+
+    let mut dictionary = dict! {
+        "bar": true,
+    };
+    let other = dict! {
+        "bar": "new",
+    };
+    dictionary.extend_dictionary(other, true);
+    assert_eq!(dictionary.get("bar".to_variant()), Some("new".to_variant()));
+}
+
+#[itest]
+fn dictionary_remove() {
+    let mut dictionary = dict! {
+        "foo": 0,
+    };
+    assert_eq!(dictionary.remove("foo".to_variant()), Some(0.to_variant()));
+    assert!(!dictionary.contains_key("foo".to_variant()));
+    assert!(dictionary.is_empty());
+}
+
+#[itest]
+fn dictionary_clear() {
+    let mut dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+        "baz": "foobar"
+    };
+
+    assert!(!dictionary.is_empty());
+    dictionary.clear();
+    assert!(dictionary.is_empty());
+}
+
+#[itest]
+fn dictionary_find_key() {
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+    };
+
+    assert_eq!(
+        dictionary.find_key(0.to_variant()),
+        Some("foo".to_variant())
+    );
+    assert_eq!(
+        dictionary.find_key(true.to_variant()),
+        Some("bar".to_variant())
+    );
+}
+
+#[itest]
+fn dictionary_contains_keys() {
+    use godot::prelude::Array;
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+    };
+
+    assert!(dictionary.contains_key("foo"), "key = \"foo\"");
+    assert!(dictionary.contains_key("bar"), "key = \"bar\"");
+    assert!(
+        dictionary.contains_all_keys(Array::from(&["foo", "bar"])),
+        "keys = [\"foo\", \"bar\"]"
+    );
+    assert!(!dictionary.contains_key("missing"), "key = \"missing\"");
+    assert!(
+        !dictionary.contains_all_keys(Array::from(&["foo", "bar", "missing"])),
+        "keys = [\"foo\", \"bar\", \"missing\"]"
+    );
+}
+
+#[itest]
+fn dictionary_keys_values() {
+    use godot::prelude::Array;
+    let dictionary = dict! {
+        "foo": 0,
+        "bar": true,
+    };
+
+    assert_eq!(dictionary.keys(), Array::from(&["foo", "bar"]));
+    assert_eq!(
+        dictionary.values(),
+        Array::from(&[0.to_variant(), true.to_variant()])
+    );
+}
+
+#[itest]
+fn dictionary_equal() {
+    assert_eq!(dict! {"foo": "bar"}, dict! {"foo": "bar"});
+    assert_eq!(dict! {1: f32::NAN}, dict! {1: f32::NAN}); // yes apparently godot considers these equal
+    assert_ne!(dict! {"foo": "bar"}, dict! {"bar": "foo"});
+}

--- a/itest/rust/src/dictionary_test.rs
+++ b/itest/rust/src/dictionary_test.rs
@@ -8,9 +8,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::itest;
 use godot::{
-    builtin::{Dictionary, FromVariant, ToVariant},
+    builtin::{dict, Dictionary, FromVariant, ToVariant},
     prelude::{Share, Variant},
-    private::class_macros::dict,
 };
 
 pub fn run() -> bool {

--- a/itest/rust/src/dictionary_test.rs
+++ b/itest/rust/src/dictionary_test.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use crate::itest;
 use godot::{
     builtin::{Dictionary, FromVariant, ToVariant},
-    prelude::{Variant, Share},
+    prelude::{Share, Variant},
     private::class_macros::dict,
 };
 
@@ -54,30 +54,14 @@ fn dictionary_from_iterator() {
     let dictionary = Dictionary::from_iter([("foo", 1), ("bar", 2)]);
 
     assert_eq!(dictionary.len(), 2);
-    assert_eq!(
-        dictionary.get("foo"),
-        Some(1.to_variant()),
-        "key = \"foo\""
-    );
-    assert_eq!(
-        dictionary.get("bar"),
-        Some(2.to_variant()),
-        "key = \"bar\""
-    );
+    assert_eq!(dictionary.get("foo"), Some(1.to_variant()), "key = \"foo\"");
+    assert_eq!(dictionary.get("bar"), Some(2.to_variant()), "key = \"bar\"");
 
     let dictionary = Dictionary::from_iter([(1, "foo"), (2, "bar")]);
 
     assert_eq!(dictionary.len(), 2);
-    assert_eq!(
-        dictionary.get(1),
-        Some("foo".to_variant()),
-        "key = 1"
-    );
-    assert_eq!(
-        dictionary.get(2),
-        Some("bar".to_variant()),
-        "key = 2"
-    );
+    assert_eq!(dictionary.get(1), Some("foo".to_variant()), "key = 1");
+    assert_eq!(dictionary.get(2), Some("bar".to_variant()), "key = 2");
 }
 
 #[itest]
@@ -85,30 +69,14 @@ fn dictionary_from() {
     let dictionary = Dictionary::from(&HashMap::from([("foo", 1), ("bar", 2)]));
 
     assert_eq!(dictionary.len(), 2);
-    assert_eq!(
-        dictionary.get("foo"),
-        Some(1.to_variant()),
-        "key = \"foo\""
-    );
-    assert_eq!(
-        dictionary.get("bar"),
-        Some(2.to_variant()),
-        "key = \"bar\""
-    );
+    assert_eq!(dictionary.get("foo"), Some(1.to_variant()), "key = \"foo\"");
+    assert_eq!(dictionary.get("bar"), Some(2.to_variant()), "key = \"bar\"");
 
     let dictionary = Dictionary::from(&HashMap::from([(1, "foo"), (2, "bar")]));
 
     assert_eq!(dictionary.len(), 2);
-    assert_eq!(
-        dictionary.get(1),
-        Some("foo".to_variant()),
-        "key = \"foo\""
-    );
-    assert_eq!(
-        dictionary.get(2),
-        Some("bar".to_variant()),
-        "key = \"bar\""
-    );
+    assert_eq!(dictionary.get(1), Some("foo".to_variant()), "key = \"foo\"");
+    assert_eq!(dictionary.get(2), Some("bar".to_variant()), "key = \"bar\"");
 }
 
 #[itest]
@@ -120,11 +88,7 @@ fn dictionary_macro() {
     };
 
     assert_eq!(dictionary.len(), 3);
-    assert_eq!(
-        dictionary.get("foo"),
-        Some(0.to_variant()),
-        "key = \"foo\""
-    );
+    assert_eq!(dictionary.get("foo"), Some(0.to_variant()), "key = \"foo\"");
     assert_eq!(
         dictionary.get("bar"),
         Some(true.to_variant()),
@@ -197,10 +161,7 @@ fn dictionary_clone() {
     Dictionary::try_from_variant(&clone.get("bar").unwrap())
         .unwrap()
         .insert("final", 4);
-    assert_eq!(
-        subdictionary.get("final"),
-        Some(4.to_variant())
-    );
+    assert_eq!(subdictionary.get("final"), Some(4.to_variant()));
 }
 
 #[itest]
@@ -269,30 +230,15 @@ fn dictionary_get() {
 
     dictionary.insert("baz", "foobar");
 
-    assert_eq!(
-        dictionary.get("foo"),
-        Some(0.to_variant()),
-        "key = \"foo\""
-    );
+    assert_eq!(dictionary.get("foo"), Some(0.to_variant()), "key = \"foo\"");
     assert_eq!(
         dictionary.get("bar"),
         Some(true.to_variant()),
         "key = \"bar\""
     );
-    assert_eq!(
-        dictionary.get("baz"),
-        Some("foobar".to_variant())
-    );
-    assert_eq!(
-        dictionary.get("nil"),
-        Some(Variant::nil()),
-        "key = \"nil\""
-    );
-    assert_eq!(
-        dictionary.get("missing"),
-        None,
-        "key = \"missing\""
-    );
+    assert_eq!(dictionary.get("baz"), Some("foobar".to_variant()));
+    assert_eq!(dictionary.get("nil"), Some(Variant::nil()), "key = \"nil\"");
+    assert_eq!(dictionary.get("missing"), None, "key = \"missing\"");
     assert_eq!(
         dictionary.get_or_nil("nil"),
         Variant::nil(),
@@ -303,11 +249,7 @@ fn dictionary_get() {
         Variant::nil(),
         "key = \"missing\""
     );
-    assert_eq!(
-        dictionary.get("foobar"),
-        None,
-        "key = \"foobar\""
-    );
+    assert_eq!(dictionary.get("foobar"), None, "key = \"foobar\"");
 }
 
 #[itest]
@@ -317,10 +259,7 @@ fn dictionary_insert() {
         "bar": 1,
     };
 
-    assert_eq!(
-        dictionary.insert("bar", 2),
-        Some(1.to_variant())
-    );
+    assert_eq!(dictionary.insert("bar", 2), Some(1.to_variant()));
     assert_eq!(
         HashMap::<String, i64>::try_from(&dictionary),
         Ok(HashMap::from([("foo".into(), 0), ("bar".into(), 2)]))
@@ -328,7 +267,11 @@ fn dictionary_insert() {
     assert_eq!(dictionary.insert("baz", 3), None);
     assert_eq!(
         HashMap::<String, i64>::try_from(&dictionary),
-        Ok(HashMap::from([("foo".into(), 0), ("bar".into(), 2), ("baz".into(), 3)]))
+        Ok(HashMap::from([
+            ("foo".into(), 0),
+            ("bar".into(), 2),
+            ("baz".into(), 3)
+        ]))
     );
 }
 
@@ -349,10 +292,7 @@ fn dictionary_insert_multiple() {
 #[itest]
 fn dictionary_insert_long() {
     let mut dictionary = dict! {};
-    let old = dictionary.insert(
-        "abcdefghijklmnopqrstuvwxyz",
-        "zabcdefghijklmnopqrstuvwxy",
-    );
+    let old = dictionary.insert("abcdefghijklmnopqrstuvwxyz", "zabcdefghijklmnopqrstuvwxy");
     assert_eq!(old, None);
     assert_eq!(
         dictionary.get("abcdefghijklmnopqrstuvwxyz"),
@@ -415,14 +355,8 @@ fn dictionary_find_key() {
         "bar": true,
     };
 
-    assert_eq!(
-        dictionary.find_key_by_value(0),
-        Some("foo".to_variant())
-    );
-    assert_eq!(
-        dictionary.find_key_by_value(true),
-        Some("bar".to_variant())
-    );
+    assert_eq!(dictionary.find_key_by_value(0), Some("foo".to_variant()));
+    assert_eq!(dictionary.find_key_by_value(true), Some("bar".to_variant()));
 }
 
 #[itest]

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -15,6 +15,7 @@ use std::panic::UnwindSafe;
 mod array_test;
 mod base_test;
 mod builtin_test;
+mod dictionary_test;
 mod enum_test;
 mod export_test;
 mod gdscript_ffi_test;
@@ -40,6 +41,7 @@ fn run_tests() -> bool {
     ok &= string_test::run();
     ok &= array_test::run();
     ok &= packed_array_test::run();
+    ok &= dictionary_test::run();
     ok &= utilities_test::run();
     ok &= variant_test::run();
     ok &= virtual_methods_test::run();

--- a/itest/rust/src/variant_test.rs
+++ b/itest/rust/src/variant_test.rs
@@ -64,7 +64,7 @@ fn variant_conversions() {
     roundtrip(gstr("some string"));
     roundtrip(String::from("some other string"));
     let str_val = "abcdefghijklmnop";
-    let back = String::try_from_variant(&str_val.to_variant()).unwrap();
+    let back = String::from_variant(&str_val.to_variant());
     assert_eq!(str_val, back.as_str());
 }
 

--- a/itest/rust/src/variant_test.rs
+++ b/itest/rust/src/variant_test.rs
@@ -39,7 +39,6 @@ fn variant_nil() {
 fn variant_conversions() {
     roundtrip(false);
     roundtrip(true);
-    roundtrip(gstr("some string"));
     roundtrip(InstanceId::from_nonzero(-9223372036854775808i64));
     // roundtrip(Some(InstanceId::from_nonzero(9223372036854775807i64)));
     // roundtrip(Option::<InstanceId>::None);
@@ -60,6 +59,13 @@ fn variant_conversions() {
     roundtrip(2147483647i32);
     roundtrip(-2147483648i32);
     roundtrip(9223372036854775807i64);
+
+    // string
+    roundtrip(gstr("some string"));
+    roundtrip(String::from("some other string"));
+    let str_val = "abcdefghijklmnop";
+    let back = String::try_from_variant(&str_val.to_variant()).unwrap();
+    assert_eq!(str_val, back.as_str());
 }
 
 #[itest]


### PR DESCRIPTION
Add basic dictionary impl with:
- `From` for `HashMap` and `HashSet` (with true as the values)
- `FromIterator` for `(K,V)`
- methods from godot, or a rusty substitute 
- `dict!` macro to easily make dictionaries godot-style

missing:
- iteration
- `get_mut` (and other `_mut` functions)
- Entry-api (if possible)
- `key = value` syntax for `dict!` macro

The added `PartialEq => array_operator_equal` impl in `Array` is there to simplify a test, but can be removed. But i think it's gonna be added eventually anyway.

I'm also not entirely sure about the safety of using dictionaries, my guess is that it's the same as for array though.