### PR TITLE
Address sanitizers in integration tests

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -14,7 +14,7 @@ on:
       - trying
 
 env:
-  GDEXT_FEATURES: 'godot-core/convenience'
+  GDEXT_FEATURES: '--features godot-core/convenience'
 #  GDEXT_CRATE_ARGS: '-p godot-codegen -p godot-ffi -p godot-core -p godot-macros -p godot'
 
 defaults:
@@ -59,8 +59,9 @@ jobs:
           binary-filename: godot.linuxbsd.editor.dev.x86_64
 
       - name: "Check clippy"
-        run: cargo clippy -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented
-
+        run: |
+          cargo clippy --all-targets $GDEXT_FEATURES -- -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf \
+          -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings
 
   unit-test:
     name: unit-test (${{ matrix.name }}${{ matrix.rust-special }})

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -63,6 +63,7 @@ jobs:
           cargo clippy --all-targets $GDEXT_FEATURES -- -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf \
           -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings
 
+
   unit-test:
     name: unit-test (${{ matrix.name }}${{ matrix.rust-special }})
     runs-on: ${{ matrix.os }}
@@ -127,7 +128,7 @@ jobs:
           binary-filename: ${{ matrix.godot-binary }}
 
       - name: "Compile tests"
-        run: cargo test --no-run
+        run: cargo test $GDEXT_FEATURES --no-run
 
       - name: "Test"
         run: cargo test $GDEXT_FEATURES
@@ -136,7 +137,8 @@ jobs:
   godot-itest:
     name: godot-itest (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: false
+    # TODO: continue-on-error: false, as soon as memory errors are fixed
+    continue-on-error: ${{ contains(matrix.name, 'memcheck') }}
     timeout-minutes: 24
     strategy:
       fail-fast: false # cancel all jobs as soon as one fails?
@@ -161,6 +163,16 @@ jobs:
             os: ubuntu-20.04
             rust-toolchain: stable
             godot-binary: godot.linuxbsd.editor.dev.x86_64
+
+          - name: linux-memcheck-gcc
+            os: ubuntu-20.04
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64.san
+
+          - name: linux-memcheck-clang
+            os: ubuntu-20.04
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -14,7 +14,7 @@ on:
       - master
 
 env:
-  GDEXT_FEATURES: 'godot-core/convenience'
+  GDEXT_FEATURES: '--features godot-core/convenience'
 #  GDEXT_CRATE_ARGS: '-p godot-codegen -p godot-ffi -p godot-core -p godot-macros -p godot'
 
 defaults:
@@ -59,7 +59,9 @@ jobs:
           binary-filename: godot.linuxbsd.editor.dev.x86_64
 
       - name: "Check clippy"
-        run: cargo clippy -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented
+        run: |
+          cargo clippy --all-targets $GDEXT_FEATURES -- -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf \
+          -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings
 
 
   unit-test:

--- a/check.sh
+++ b/check.sh
@@ -76,7 +76,7 @@ for arg in "${args[@]}"; do
         cmds+=("cargo fmt --all -- --check")
         ;;
     clippy)
-        cmds+=("cargo clippy $features -- -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings")
+        cmds+=("cargo clippy $features -- -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings")
         ;;
     test)
         cmds+=("cargo test $features")

--- a/godot-core/src/builtin/dictionary.rs
+++ b/godot-core/src/builtin/dictionary.rs
@@ -328,7 +328,7 @@ impl Share for Dictionary {
 ///
 /// Example
 /// ```no_run
-/// use godot::builtin::dict;
+/// use godot::builtin::{dict, Variant};
 ///
 /// let key = "my_key";
 /// let d = dict! {
@@ -336,7 +336,7 @@ impl Share for Dictionary {
 ///     "another": Variant::nil(),
 ///     key: true,
 ///     (1 + 2): "final",
-/// }
+/// };
 /// ```
 #[macro_export]
 macro_rules! dict {

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -99,6 +99,7 @@ pub use godot_core::private;
 /// Often-imported symbols.
 pub mod prelude {
     pub use super::bind::{godot_api, GodotClass, GodotExt};
+    pub use super::builtin::dict; // Re-export macros.
     pub use super::builtin::*;
     pub use super::engine::{
         load, try_load, utilities, AudioStreamPlayer, Camera2D, Camera3D, Input, Node, Node2D,


### PR DESCRIPTION
Also makes clippy more strict and fixes doctests on `master`.

Integration tests with address sanitizers currently support two setups (gcc + clang), and are allowed to fail until some of the underlying issues like #89 are fixed. Unless the two variants report different findings, we may reduce CI to use only one of the two memory checkers in the future.