### PR TITLE
Remove feature `convenience`

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -14,7 +14,8 @@ on:
       - trying
 
 env:
-  GDEXT_FEATURES: '--features godot-core/convenience'
+  GDEXT_FEATURES: ''
+#  GDEXT_FEATURES: '--features crate/feature'
 #  GDEXT_CRATE_ARGS: '-p godot-codegen -p godot-ffi -p godot-core -p godot-macros -p godot'
 
 defaults:

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -14,7 +14,8 @@ on:
       - master
 
 env:
-  GDEXT_FEATURES: '--features godot-core/convenience'
+  GDEXT_FEATURES: ''
+#  GDEXT_FEATURES: '--features crate/feature'
 #  GDEXT_CRATE_ARGS: '-p godot-codegen -p godot-ffi -p godot-core -p godot-macros -p godot'
 
 defaults:

--- a/check.sh
+++ b/check.sh
@@ -67,7 +67,8 @@ function findGodot() {
     fi
 }
 
-features="--features godot-core/convenience"
+#features="--features crate/feature"
+features=""
 cmds=()
 
 for arg in "${args[@]}"; do

--- a/examples/dodge-the-creeps/rust/Cargo.toml
+++ b/examples/dodge-the-creeps/rust/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = { path = "../../../godot", default-features = false, features = ["formatted", "convenience"] }
+godot = { path = "../../../godot", default-features = false, features = ["formatted"] }
 rand = "0.8"

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -12,7 +12,6 @@ default = []
 trace = []
 codegen-fmt = ["godot-ffi/codegen-fmt"]
 codegen-full = ["godot-codegen/codegen-full"]
-convenience = []
 
 [dependencies]
 godot-ffi = { path = "../godot-ffi" }

--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -40,13 +40,12 @@ impl Variant {
         value.to_variant()
     }
 
-    /// Convert to type `T`, panicking on failure.
+    /// ⚠️ Convert to type `T`, panicking on failure.
     ///
     /// Equivalent to `T::from_variant(&self)`.
     ///
     /// # Panics
     /// When this variant holds a different type.
-    #[cfg(feature = "convenience")]
     pub fn to<T: FromVariant>(&self) -> T {
         T::from_variant(self)
     }

--- a/godot-core/src/builtin/variant/variant_traits.rs
+++ b/godot-core/src/builtin/variant/variant_traits.rs
@@ -6,10 +6,15 @@
 
 use crate::builtin::Variant;
 
+/// Trait to enable conversions of types _from_ the [`Variant`] type.
 pub trait FromVariant: Sized {
+    /// Tries to convert a `Variant` to `Self`, allowing to check the success or failure.
     fn try_from_variant(variant: &Variant) -> Result<Self, VariantConversionError>;
 
-    #[cfg(feature = "convenience")]
+    /// ⚠️ Converts from `Variant` to `Self`, panicking on error.
+    ///
+    /// This method should generally not be overridden by trait impls, even if conversions are infallible.
+    /// Implementing [`Self::try_from_variant`] suffices.
     fn from_variant(variant: &Variant) -> Self {
         Self::try_from_variant(variant).unwrap_or_else(|e| {
             panic!(
@@ -22,6 +27,7 @@ pub trait FromVariant: Sized {
     }
 }
 
+/// Trait to enable conversions of types _to_ the [`Variant`] type.
 pub trait ToVariant {
     /*fn try_to_variant(&self) -> Result<Variant, VariantConversionError>;
 
@@ -35,6 +41,9 @@ pub trait ToVariant {
         })
     }*/
 
+    /// Infallible conversion from `Self` type to `Variant`.
+    ///
+    /// This method must not panic. If your conversion is fallible, this trait should not be used.
     fn to_variant(&self) -> Variant;
 }
 

--- a/godot-core/src/obj/instance_id.rs
+++ b/godot-core/src/obj/instance_id.rs
@@ -26,17 +26,18 @@ pub struct InstanceId {
 
 impl InstanceId {
     /// Constructs an instance ID from an integer, or `None` if the integer is zero.
+    ///
+    /// This does *not* check if the instance is valid.
     pub fn try_from_i64(id: i64) -> Option<Self> {
         Self::try_from_u64(id as u64)
     }
 
-    /// Constructs an instance ID from a non-zero integer, or panics.
+    /// ⚠️ Constructs an instance ID from a non-zero integer, or panics.
     ///
     /// This does *not* check if the instance is valid.
     ///
     /// # Panics
     /// If `id` is zero.
-    #[cfg(feature = "convenience")]
     pub fn from_nonzero(id: i64) -> Self {
         Self::try_from_i64(id).expect("expected non-zero instance ID")
     }

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -8,8 +8,7 @@ keywords = ["gamedev", "godot", "engine", "2d", "3d"] # possibly: "ffi"
 categories = ["game-engines", "graphics"]
 
 [features]
-default = ["convenience", "codegen-full"]
-convenience = ["godot-core/convenience"]
+default = ["codegen-full"]
 formatted = ["godot-core/codegen-fmt"]
 trace = ["godot-core/trace"]
 

--- a/godot/src/lib.rs
+++ b/godot/src/lib.rs
@@ -57,6 +57,34 @@
 //!    you must either hand over ownership to Godot (e.g. by adding a node to the scene tree) or
 //!    free them manually using [`Gd::free()`][crate::obj::Gd::free]. <br><br>
 //!
+//! # Ergonomics and panics
+//!
+//! The GDExtension Rust bindings are designed with usage ergonomics in mind, making them viable
+//! for fast prototyping. Part of this design means that users should not constantly be forced
+//! to write code such as `obj.cast::<T>().unwrap()`. Instead, they can just write `obj.cast::<T>()`,
+//! which may panic at runtime.
+//!
+//! This approach has several advantages:
+//! * The code is more concise and less cluttered.
+//! * Methods like `cast()` provide very sophisticated panic messages when they fail (e.g. involved
+//!   classes), immediately giving you the necessary context for debugging. This is certainly
+//!   preferable over a generic `unwrap()`, and in most cases also over a `expect("literal")`.
+//! * Usually, such methods panicking indicate bugs in the application. For example, you have a static
+//!   scene tree, and you _know_ that a node of certain type and name exists. `get_node_as::<T>("name")`
+//!   thus _must_ succeed, or your mental concept is wrong. In other words, there is not much you can
+//!   do at runtime to recover from such errors anyway; the code needs to be fixed.
+//!
+//! Now, there are of course cases where you _do_ want to check certain assumptions dynamically.
+//! Imagine a scene tree that is constructed at runtime, e.g. in a game editor.
+//! This is why the library provides "overloads" for most of these methods that return `Option` or `Result`.
+//! Such methods have more verbose names and highlight the attempt, e.g. `try_cast()`.
+//!
+//! To help you identify panicking methods, we use the symbol "⚠️" at the beginning of the documentation;
+//! this should also appear immediately in the auto-completion of your IDE. Note that this warning sign is
+//! not used as a general panic indicator, but particularly for methods which have a `Option`/`Result`-based
+//! overload. If you want to know whether and how a method can panic, check if its documentation has a
+//! _Panics_ section.
+//!
 //! # Thread safety
 //!
 //! [Godot's own thread safety

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 trace = ["godot/trace"]
 
 [dependencies]
-godot = { path = "../../godot", default-features = false, features = ["formatted", "convenience"] }
+godot = { path = "../../godot", default-features = false, features = ["formatted"] }
 
 [build-dependencies]
 quote = "1"


### PR DESCRIPTION
Instead prepends panicking methods with the ⚠️ symbol (if they have a "try" overload). 
This should show up first in docs and IDE auto-completion.

Also adds crate-level docs about the design behind our ergonomics and fast prototyping.

Closes #60.