### PR TITLE
Implement static methods for engine + builtin classes

### DIFF
--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -172,7 +172,7 @@ pub struct ClassMethod {
     pub name: String,
     pub is_const: bool,
     pub is_vararg: bool,
-    //pub is_static: bool,
+    pub is_static: bool,
     pub is_virtual: bool,
     pub hash: Option<i64>,
     pub return_value: Option<MethodReturn>,

--- a/godot-core/src/builtin/color.rs
+++ b/godot-core/src/builtin/color.rs
@@ -17,7 +17,6 @@ pub struct Color {
 }
 
 impl Color {
-    #[allow(dead_code)]
     pub fn new(r: f32, g: f32, b: f32, a: f32) -> Self {
         Self { r, g, b, a }
     }

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -488,6 +488,9 @@ impl<T: GodotClass> Gd<T> {
     /// Runs `init_fn` on the address of a pointer (initialized to null). If that pointer is still null after the `init_fn` call,
     /// then `None` will be returned; otherwise `Gd::from_obj_sys(ptr)`.
     ///
+    /// This method will **NOT** increment the reference-count of the object, as it assumes the input to come from a Godot API
+    /// return value.
+    ///
     /// # Safety
     /// `init_fn` must be a function that correctly handles a _type pointer_ pointing to an _object pointer_.
     #[doc(hidden)]
@@ -496,7 +499,9 @@ impl<T: GodotClass> Gd<T> {
 
         // Initialize pointer with given function, return Some(ptr) on success and None otherwise
         let object_ptr = raw_object_init(init_fn);
-        sys::ptr_then(object_ptr, |ptr| Gd::from_obj_sys(ptr))
+
+        // Do not increment ref-count; assumed to be return value from FFI.
+        sys::ptr_then(object_ptr, |ptr| Gd::from_obj_sys_weak(ptr))
     }
 }
 

--- a/itest/rust/src/codegen_test.rs
+++ b/itest/rust/src/codegen_test.rs
@@ -4,17 +4,20 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-// This file tests the presence and naming of generated symbols, not their functionality.
+// This file tests the presence, naming and accessibility of generated symbols.
+// Functionality is only tested on a superficial level (to make sure general FFI mechanisms work).
 
 use crate::itest;
-
-use godot::engine::HttpRequest;
+use godot::builtin::inner::{InnerColor, InnerString};
+use godot::engine::{FileAccess, HttpRequest};
 use godot::prelude::*;
 
 pub fn run() -> bool {
     let mut ok = true;
     ok &= codegen_class_renamed();
     ok &= codegen_base_renamed();
+    ok &= codegen_static_builtin_method();
+    ok &= codegen_static_class_method();
     ok
 }
 
@@ -35,6 +38,28 @@ fn codegen_base_renamed() {
 
     obj.free();
 }
+
+#[itest]
+fn codegen_static_builtin_method() {
+    let pi = InnerString::num(std::f64::consts::PI, 3);
+    assert_eq!(pi, GodotString::from("3.142"));
+
+    let col = InnerColor::html("#663399cc".into());
+    assert_eq!(col, Color::new(0.4, 0.2, 0.6, 0.8));
+}
+
+#[itest]
+fn codegen_static_class_method() {
+    let exists = FileAccess::file_exists("inexistent".into());
+    assert!(!exists);
+
+    let exists = FileAccess::file_exists("res://itest.gdextension".into());
+    assert!(exists);
+
+    // see also object_test for reference count verification
+}
+
+// ----------------------------------------------------------------------------------------------------------------------------------------------
 
 #[derive(GodotClass)]
 #[class(base=HttpRequest)]

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -7,7 +7,7 @@
 use crate::{expect_panic, itest};
 use godot::bind::{godot_api, GodotClass, GodotExt};
 use godot::builtin::{FromVariant, GodotString, StringName, ToVariant, Variant, Vector3};
-use godot::engine::{Node, Node3D, Object, RefCounted};
+use godot::engine::{file_access, FileAccess, Node, Node3D, Object, RefCounted};
 use godot::obj::Share;
 use godot::obj::{Base, Gd, InstanceId};
 use godot::sys::GodotFfi;
@@ -38,6 +38,7 @@ pub fn run() -> bool {
     ok &= object_engine_convert_variant();
     ok &= object_user_convert_variant_refcount();
     ok &= object_engine_convert_variant_refcount();
+    ok &= object_engine_returned_refcount();
     ok &= object_engine_up_deref();
     ok &= object_engine_up_deref_mut();
     ok &= object_engine_upcast();
@@ -263,6 +264,17 @@ fn check_convert_variant_refcount(obj: Gd<RefCounted>) {
 
     // `variant` destroyed -> decrement
     assert_eq!(obj.get_reference_count(), 1);
+}
+
+#[itest]
+fn object_engine_returned_refcount() {
+    let Some(file) = FileAccess::open("res://itest.gdextension".into(), file_access::ModeFlags::READ) else {
+        panic!("failed to open file used to test FileAccess")
+    };
+    assert!(file.is_open());
+
+    // There was a bug which incremented ref-counts of just-returned objects, keep this as regression test.
+    assert_eq!(file.get_reference_count(), 1);
 }
 
 #[itest]


### PR DESCRIPTION
Also fixes a memory leak when `RefCounted` instances are returned from engine methods.

Closes #43.
