### PR TITLE
#[export] infer `VariantType`

### DIFF
--- a/godot-core/src/builtin/meta/mod.rs
+++ b/godot-core/src/builtin/meta/mod.rs
@@ -39,6 +39,12 @@ pub trait VariantMetadata {
     }
 }
 
+impl<T: VariantMetadata> VariantMetadata for Option<T> {
+    fn variant_type() -> VariantType {
+        T::variant_type()
+    }
+}
+
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 
 /// Rusty abstraction of sys::GDExtensionPropertyInfo

--- a/itest/rust/src/export_test.rs
+++ b/itest/rust/src/export_test.rs
@@ -13,23 +13,11 @@ use godot::prelude::*;
 struct HasProperty {
     #[base]
     base: Base<Node>,
-    #[export(
-        getter = "get_int_val",
-        setter = "set_int_val",
-        variant_type = "::godot::sys::VariantType::Int"
-    )]
+    #[export(getter = "get_int_val", setter = "set_int_val")]
     int_val: i32,
-    #[export(
-        getter = "get_string_val",
-        setter = "set_string_val",
-        variant_type = "::godot::sys::VariantType::String"
-    )]
+    #[export(getter = "get_string_val", setter = "set_string_val")]
     string_val: GodotString,
-    #[export(
-        getter = "get_object_val",
-        setter = "set_object_val",
-        variant_type = "::godot::sys::VariantType::Object"
-    )]
+    #[export(getter = "get_object_val", setter = "set_object_val")]
     object_val: Option<Gd<Object>>,
 }
 


### PR DESCRIPTION
I removed the explicit `VariantType` declaration and replaced it with the ability to infer the same.

Also added an implementation for `VariantMetadata` for `Option` not sure if this is good but it was necessary.