### PR TITLE
Add support for `precision=double` builds of godot

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -44,7 +44,20 @@ jobs:
 
 
   clippy:
+    name: clippy (${{ matrix.name }})
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: 
+          - name: linux
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+          
+          - name: linux-double
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.double.x86_64
+            rust-extra-args: --features double-precision
     steps:
       - uses: actions/checkout@v3
 
@@ -56,13 +69,14 @@ jobs:
       - name: "Install Godot"
         uses: ./.github/composite/godot-install
         with:
-          artifact-name: godot-linux
-          godot-binary: godot.linuxbsd.editor.dev.x86_64
+          artifact-name: godot-${{ matrix.name }}
+          godot-binary: ${{ matrix.godot-binary }}
 
       - name: "Check clippy"
         run: |
-          cargo clippy --all-targets $GDEXT_FEATURES -- -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf \
-          -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings
+          cargo clippy --all-targets $GDEXT_FEATURES ${{ matrix.rust-extra-args }} -- \
+          -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf \
+          -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings 
 
 
   unit-test:
@@ -80,11 +94,23 @@ jobs:
             os: macos-11
             rust-toolchain: stable
             godot-binary: godot.macos.editor.dev.x86_64
+            with-llvm: true
+
+          - name: macos-double
+            os: macos-11
+            rust-toolchain: stable
+            godot-binary: godot.macos.editor.dev.double.x86_64
+            with-llvm: true
 
           - name: windows
             os: windows-latest
             rust-toolchain: stable-x86_64-pc-windows-msvc
             godot-binary: godot.windows.editor.dev.x86_64.exe
+
+          - name: windows-double
+            os: windows-latest
+            rust-toolchain: stable-x86_64-pc-windows-msvc
+            godot-binary: godot.windows.editor.dev.double.x86_64.exe
 
           # Don't use latest Ubuntu (22.04) as it breaks lots of ecosystem compatibility.
           # If ever moving to ubuntu-latest, need to manually install libtinfo5 for LLVM.
@@ -98,6 +124,12 @@ jobs:
             rust-toolchain: stable
             rust-special: -minimal-deps
             godot-binary: godot.linuxbsd.editor.dev.x86_64
+          
+          - name: linux-double
+            os: ubuntu-20.04
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.double.x86_64
+            rust-extra-args: --features double-precision
 
     steps:
       - uses: actions/checkout@v3
@@ -107,7 +139,7 @@ jobs:
         with:
           rust: stable
           cache-key: ${{ matrix.rust-special }} # 'minimal-deps' or empty/not defined
-          with-llvm: ${{ matrix.name == 'macos' }}
+          with-llvm: ${{ matrix.with-llvm }}
 
       - name: "Install Rust nightly (minimal deps)"
         uses: ./.github/composite/rust
@@ -129,10 +161,10 @@ jobs:
           godot-binary: ${{ matrix.godot-binary }}
 
       - name: "Compile tests"
-        run: cargo test $GDEXT_FEATURES --no-run
+        run: cargo test $GDEXT_FEATURES --no-run ${{ matrix.rust-extra-args }}
 
       - name: "Test"
-        run: cargo test $GDEXT_FEATURES
+        run: cargo test $GDEXT_FEATURES ${{ matrix.rust-extra-args }}
 
 
   godot-itest:
@@ -151,11 +183,25 @@ jobs:
             os: macos-12
             rust-toolchain: stable
             godot-binary: godot.macos.editor.dev.x86_64
+            with-llvm: true
+          
+          - name: macos-double
+            os: macos-12
+            rust-toolchain: stable
+            godot-binary: godot.macos.editor.dev.double.x86_64
+            rust-extra-args: --features double-precision
+            with-llvm: true
 
           - name: windows
             os: windows-latest
             rust-toolchain: stable-x86_64-pc-windows-msvc
             godot-binary: godot.windows.editor.dev.x86_64.exe
+
+          - name: windows-double
+            os: windows-latest
+            rust-toolchain: stable-x86_64-pc-windows-msvc
+            godot-binary: godot.windows.editor.dev.double.x86_64.exe
+            rust-extra-args: --features double-precision
 
           # Don't use latest Ubuntu (22.04) as it breaks lots of ecosystem compatibility.
           # If ever moving to ubuntu-latest, need to manually install libtinfo5 for LLVM.
@@ -182,6 +228,12 @@ jobs:
             godot-binary: godot.linuxbsd.editor.dev.x86_64.llvm.san
             godot-args: -- --disallow-focus
 
+          - name: linux-double
+            os: ubuntu-20.04
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.double.x86_64
+            rust-extra-args: --features double-precision
+
     steps:
       - uses: actions/checkout@v3
 
@@ -191,7 +243,8 @@ jobs:
           artifact-name: godot-${{ matrix.name }}
           godot-binary: ${{ matrix.godot-binary }}
           godot-args: ${{ matrix.godot-args }}
-          with-llvm: ${{ matrix.name == 'macos' }}
+          with-llvm: ${{ matrix.with-llvm }}
+          rust-extra-args: ${{ matrix.rust-extra-args }}
 
 
   license-guard:

--- a/.github/workflows/minimal-ci.yml
+++ b/.github/workflows/minimal-ci.yml
@@ -44,7 +44,20 @@ jobs:
 
 
   clippy:
+    name: clippy (${{ matrix.name }})
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: 
+          - name: linux
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.x86_64
+          
+          - name: linux-double
+            rust-toolchain: stable
+            godot-binary: godot.linuxbsd.editor.dev.double.x86_64
+            rust-extra-args: --features double-precision
     steps:
       - uses: actions/checkout@v3
 
@@ -56,12 +69,13 @@ jobs:
       - name: "Install Godot"
         uses: ./.github/composite/godot-install
         with:
-          artifact-name: godot-linux
-          godot-binary: godot.linuxbsd.editor.dev.x86_64
+          artifact-name: godot-${{ matrix.name }}
+          godot-binary: ${{ matrix.godot-binary }}
 
       - name: "Check clippy"
         run: |
-          cargo clippy --all-targets $GDEXT_FEATURES -- -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf \
+          cargo clippy --all-targets $GDEXT_FEATURES ${{ matrix.rust-extra-args }} -- \
+          -D clippy::suspicious -D clippy::style -D clippy::complexity -D clippy::perf \
           -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented -D warnings
 
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -60,5 +60,16 @@ $ cargo fmt
 $ check.sh clippy
 ```
 
+## Real
+
+Certain types in Godot use either a single or double-precision float internally, such as `Vector2`. When using these types we 
+use the `real` type instead of choosing either `f32` or `f64`. Thus our code is portable between Godot binaries compiled with
+`precision=single` or `precision=double`.
+
+To run the testing suite with `double-precision` enabled you may add `--double` to a `check.sh` invocation:
+```
+$ check.sh --double
+```
+
 [GitHub issue]: https://github.com/godot-rust/gdextension/issues
 [Discord]: https://discord.gg/aKUCJ8rJsc

--- a/examples/dodge-the-creeps/rust/src/main_scene.rs
+++ b/examples/dodge-the-creeps/rust/src/main_scene.rs
@@ -104,7 +104,7 @@ impl Main {
             let range = rng.gen_range(mob.min_speed..mob.max_speed);
 
             mob.set_linear_velocity(Vector2::new(range, 0.0));
-            let lin_vel = mob.get_linear_velocity().rotated(direction as f32);
+            let lin_vel = mob.get_linear_velocity().rotated(real::from_f64(direction));
             mob.set_linear_velocity(lin_vel);
         }
 

--- a/examples/dodge-the-creeps/rust/src/mob.rs
+++ b/examples/dodge-the-creeps/rust/src/mob.rs
@@ -26,8 +26,8 @@ const MOB_TYPES: [MobType; 3] = [MobType::Walk, MobType::Swim, MobType::Fly];
 #[derive(GodotClass)]
 #[class(base=RigidBody2D)]
 pub struct Mob {
-    pub min_speed: f32,
-    pub max_speed: f32,
+    pub min_speed: real,
+    pub max_speed: real,
 
     #[base]
     base: Base<RigidBody2D>,

--- a/examples/dodge-the-creeps/rust/src/player.rs
+++ b/examples/dodge-the-creeps/rust/src/player.rs
@@ -4,7 +4,7 @@ use godot::prelude::*;
 #[derive(GodotClass)]
 #[class(base=Area2D)]
 pub struct Player {
-    speed: f32,
+    speed: real,
     screen_size: Vector2,
 
     #[base]
@@ -100,7 +100,7 @@ impl GodotExt for Player {
             animated_sprite.stop();
         }
 
-        let change = velocity * delta as f32;
+        let change = velocity * real::from_f64(delta);
         let position = self.base.get_global_position() + change;
         let position = Vector2::new(
             position.x.clamp(0.0, self.screen_size.x),

--- a/godot-codegen/Cargo.toml
+++ b/godot-codegen/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["game-engines", "graphics"]
 [features]
 codegen-fmt = []
 codegen-full = []
+double-precision = []
 
 [dependencies]
 quote = "1"

--- a/godot-codegen/src/api_parser.rs
+++ b/godot-codegen/src/api_parser.rs
@@ -222,6 +222,9 @@ pub fn load_extension_api(watch: &mut StopWatch) -> (ExtensionApi, &'static str)
     // For float/double inference, see:
     // * https://github.com/godotengine/godot-proposals/issues/892
     // * https://github.com/godotengine/godot-cpp/pull/728
+    #[cfg(feature = "double-precision")]
+    let build_config = "double_64"; // TODO infer this
+    #[cfg(not(feature = "double-precision"))]
     let build_config = "float_64"; // TODO infer this
 
     let json: String = godot_exe::load_extension_api_json(watch);

--- a/godot-core/Cargo.toml
+++ b/godot-core/Cargo.toml
@@ -12,6 +12,7 @@ default = []
 trace = []
 codegen-fmt = ["godot-ffi/codegen-fmt"]
 codegen-full = ["godot-codegen/codegen-full"]
+double-precision = ["godot-codegen/double-precision"]
 
 [dependencies]
 godot-ffi = { path = "../godot-ffi" }

--- a/godot-core/src/builtin/glam_helpers.rs
+++ b/godot-core/src/builtin/glam_helpers.rs
@@ -15,6 +15,8 @@
 //   self.glam().dot(b.glam())
 //   GlamType::dot(self.glam(), b.glam())
 
+use super::real;
+
 pub(crate) trait GlamConv {
     type Glam: GlamType<Mapped = Self>;
 
@@ -70,6 +72,6 @@ macro_rules! impl_glam_map_self {
     };
 }
 
-impl_glam_map_self!(f32);
+impl_glam_map_self!(real);
 impl_glam_map_self!(bool);
-impl_glam_map_self!((f32, f32, f32));
+impl_glam_map_self!((real, real, real));

--- a/godot-core/src/builtin/math.rs
+++ b/godot-core/src/builtin/math.rs
@@ -4,17 +4,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::f32::consts::TAU;
+use super::real_consts::TAU;
 
+use super::real;
 use super::Vector2;
 
-pub const CMP_EPSILON: f32 = 0.00001;
+pub const CMP_EPSILON: real = 0.00001;
 
-pub fn lerp(a: f32, b: f32, t: f32) -> f32 {
+pub fn lerp(a: real, b: real, t: real) -> real {
     a + ((b - a) * t)
 }
 
-pub fn is_equal_approx(a: f32, b: f32) -> bool {
+pub fn is_equal_approx(a: real, b: real) -> bool {
     if a == b {
         return true;
     }
@@ -27,9 +28,11 @@ pub fn is_equal_approx(a: f32, b: f32) -> bool {
 
 /// Check if two angles are approximately equal, by comparing the distance
 /// between the points on the unit circle with 0 using [`is_equal_approx`].
-pub fn is_angle_equal_approx(a: f32, b: f32) -> bool {
+pub fn is_angle_equal_approx(a: real, b: real) -> bool {
     let (x1, y1) = a.sin_cos();
     let (x2, y2) = b.sin_cos();
+
+    println!("({x1}, {y1}) ({x2}, {y2})");
 
     is_equal_approx(
         Vector2::distance_to(Vector2::new(x1, y1), Vector2::new(x2, y2)),
@@ -37,11 +40,11 @@ pub fn is_angle_equal_approx(a: f32, b: f32) -> bool {
     )
 }
 
-pub fn is_zero_approx(s: f32) -> bool {
+pub fn is_zero_approx(s: real) -> bool {
     s.abs() < CMP_EPSILON
 }
 
-pub fn fposmod(x: f32, y: f32) -> f32 {
+pub fn fposmod(x: real, y: real) -> real {
     let mut value = x % y;
     if ((value < 0.0) && (y > 0.0)) || ((value > 0.0) && (y < 0.0)) {
         value += y;
@@ -50,14 +53,14 @@ pub fn fposmod(x: f32, y: f32) -> f32 {
     value
 }
 
-pub fn snapped(mut value: f32, step: f32) -> f32 {
+pub fn snapped(mut value: real, step: real) -> real {
     if step != 0.0 {
         value = ((value / step + 0.5) * step).floor()
     }
     value
 }
 
-pub fn sign(value: f32) -> f32 {
+pub fn sign(value: real) -> real {
     if value == 0.0 {
         0.0
     } else if value < 0.0 {
@@ -67,7 +70,13 @@ pub fn sign(value: f32) -> f32 {
     }
 }
 
-pub fn bezier_derivative(start: f32, control_1: f32, control_2: f32, end: f32, t: f32) -> f32 {
+pub fn bezier_derivative(
+    start: real,
+    control_1: real,
+    control_2: real,
+    end: real,
+    t: real,
+) -> real {
     let omt = 1.0 - t;
     let omt2 = omt * omt;
     let t2 = t * t;
@@ -76,7 +85,13 @@ pub fn bezier_derivative(start: f32, control_1: f32, control_2: f32, end: f32, t
         + (end - control_2) * 3.0 * t2
 }
 
-pub fn bezier_interpolate(start: f32, control_1: f32, control_2: f32, end: f32, t: f32) -> f32 {
+pub fn bezier_interpolate(
+    start: real,
+    control_1: real,
+    control_2: real,
+    end: real,
+    t: real,
+) -> real {
     let omt = 1.0 - t;
     let omt2 = omt * omt;
     let omt3 = omt2 * omt;
@@ -85,7 +100,7 @@ pub fn bezier_interpolate(start: f32, control_1: f32, control_2: f32, end: f32, 
     start * omt3 + control_1 * omt2 * t * 3.0 + control_2 * omt * t2 * 3.0 + end * t3
 }
 
-pub fn cubic_interpolate(from: f32, to: f32, pre: f32, post: f32, weight: f32) -> f32 {
+pub fn cubic_interpolate(from: real, to: real, pre: real, post: real, weight: real) -> real {
     0.5 * ((from * 2.0)
         + (-pre + to) * weight
         + (2.0 * pre - 5.0 * from + 4.0 * to - post) * (weight * weight)
@@ -94,15 +109,15 @@ pub fn cubic_interpolate(from: f32, to: f32, pre: f32, post: f32, weight: f32) -
 
 #[allow(clippy::too_many_arguments)]
 pub fn cubic_interpolate_in_time(
-    from: f32,
-    to: f32,
-    pre: f32,
-    post: f32,
-    weight: f32,
-    to_t: f32,
-    pre_t: f32,
-    post_t: f32,
-) -> f32 {
+    from: real,
+    to: real,
+    pre: real,
+    post: real,
+    weight: real,
+    to_t: real,
+    pre_t: real,
+    post_t: real,
+) -> real {
     let t = lerp(0.0, to_t, weight);
     let a1 = lerp(
         pre,
@@ -147,12 +162,12 @@ pub fn cubic_interpolate_in_time(
 /// Note: This function lerps through the shortest path between `from` and
 /// `to`. However, when these two angles are approximately `PI + k * TAU` apart
 /// for any integer `k`, it's not obvious which way they lerp due to
-/// floating-point precision errors. For example, `lerp_angle(0.0, PI, weight)`
-/// lerps clockwise, while `lerp_angle(0.0, PI + 3.0 * TAU, weight)` lerps
-/// counter-clockwise.
+/// floating-point precision errors. For example, with single-precision floats
+/// `lerp_angle(0.0, PI, weight)` lerps clockwise, while `lerp_angle(0.0, PI + 3.0 * TAU, weight)`
+/// lerps counter-clockwise.
 ///
 /// _Godot equivalent: @GlobalScope.lerp_angle()_
-pub fn lerp_angle(from: f32, to: f32, weight: f32) -> f32 {
+pub fn lerp_angle(from: real, to: real, weight: real) -> real {
     let difference = (to - from) % TAU;
     let distance = (2.0 * difference) % TAU - difference;
     from + distance * weight
@@ -192,7 +207,7 @@ macro_rules! assert_ne_approx {
 
 #[cfg(test)]
 mod test {
-    use std::f32::consts::{FRAC_PI_2, PI};
+    use crate::builtin::real_consts::{FRAC_PI_2, PI};
 
     use super::*;
 
@@ -222,9 +237,21 @@ mod test {
     #[test]
     fn lerp_angle_test() {
         assert_eq_approx!(lerp_angle(0.0, PI, 0.5), -FRAC_PI_2, is_angle_equal_approx);
+        // As mentioned in the docs for `lerp_angle`, direction can be unpredictable
+        // when lerping towards PI radians, this also means it's different for single vs
+        // double precision floats.
+
+        // TODO: look into if it's possible to make a more robust impl.
+        #[cfg(not(feature = "double-precision"))]
         assert_eq_approx!(
             lerp_angle(0.0, PI + 3.0 * TAU, 0.5),
             FRAC_PI_2,
+            is_angle_equal_approx
+        );
+        #[cfg(feature = "double-precision")]
+        assert_eq_approx!(
+            lerp_angle(0.0, PI + 3.0 * TAU, 0.5),
+            -FRAC_PI_2,
             is_angle_equal_approx
         );
         let angle = PI * 2.0 / 3.0;

--- a/godot-core/src/builtin/mod.rs
+++ b/godot-core/src/builtin/mod.rs
@@ -128,3 +128,190 @@ pub(crate) fn u8_to_bool(u: u8) -> bool {
         _ => panic!("Invalid boolean value {u}"),
     }
 }
+
+/// Clippy often complains if you do `f as f64` when `f` is already an `f64`. This trait exists to make it easy to
+/// convert between the different reals and floats without a lot of allowing clippy lints for your code.
+pub trait RealConv {
+    /// Cast this [`real`] to an [`f32`] using `as`.
+    // Clippy complains that this is an `as_*` function but it takes a `self`
+    // however, since this uses `as` internally it makes much more sense for
+    // it to be named `as_f32` rather than `to_f32`.
+    #[allow(clippy::wrong_self_convention)]
+    fn as_f32(self) -> f32;
+
+    /// Cast this [`real`] to an [`f64`] using `as`.
+    // Clippy complains that this is an `as_*` function but it takes a `self`
+    // however, since this uses `as` internally it makes much more sense for
+    // it to be named `as_f64` rather than `to_f64`.
+    #[allow(clippy::wrong_self_convention)]
+    fn as_f64(self) -> f64;
+
+    /// Cast an [`f32`] to a [`real`] using `as`.
+    fn from_f32(f: f32) -> Self;
+
+    /// Cast an [`f64`] to a [`real`] using `as`.
+    fn from_f64(f: f64) -> Self;
+}
+
+#[cfg(not(feature = "double-precision"))]
+mod real_mod {
+    //! Definitions for single-precision `real`.
+
+    /// Floating point type used for many structs and functions in Godot.
+    ///
+    /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
+    /// either 32-bit or 64-bit floats such as [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
+    /// [`f64`] see [`RealConv`](super::RealConv).
+    ///
+    /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
+    ///
+    /// _Godot equivalent: `real_t`_
+    // As this is a scalar value, we will use a non-standard type name.
+    #[allow(non_camel_case_types)]
+    pub type real = f32;
+
+    impl super::RealConv for real {
+        #[inline]
+        fn as_f32(self) -> f32 {
+            self
+        }
+
+        #[inline]
+        fn as_f64(self) -> f64 {
+            self as f64
+        }
+
+        #[inline]
+        fn from_f32(f: f32) -> Self {
+            f
+        }
+
+        #[inline]
+        fn from_f64(f: f64) -> Self {
+            f as f32
+        }
+    }
+
+    pub use std::f32::consts;
+
+    /// A 2-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec2 = glam::Vec2;
+    /// A 3-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec3 = glam::Vec3;
+    /// A 4-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec4 = glam::Vec4;
+
+    /// A 2x2 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].  
+    pub type RMat2 = glam::Mat2;
+    /// A 3x3 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat3 = glam::Mat3;
+    /// A 4x4 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat4 = glam::Mat4;
+
+    /// A matrix from [`glam`] quaternion representing an orientation. Using a floating-point format compatible
+    /// with [`real`].
+    pub type RQuat = glam::Quat;
+
+    /// A 2D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine2 = glam::Affine2;
+    /// A 3D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine3 = glam::Affine3A;
+}
+
+#[cfg(feature = "double-precision")]
+mod real_mod {
+    //! Definitions for double-precision `real`.
+
+    /// Floating point type used for many structs and functions in Godot.
+    ///
+    /// This is not the `float` type in GDScript; that type is always 64-bits. Rather, many structs in Godot may use
+    /// either 32-bit or 64-bit floats such as [`Vector2`](super::Vector2). To convert between [`real`] and [`f32`] or
+    /// [`f64`] see [`RealConv`](super::RealConv).
+    ///
+    /// See also the [Godot docs on float](https://docs.godotengine.org/en/stable/classes/class_float.html).
+    ///
+    /// _Godot equivalent: `real_t`_
+    // As this is a scalar value, we will use a non-standard type name.
+    #[allow(non_camel_case_types)]
+    pub type real = f64;
+
+    impl super::RealConv for real {
+        #[inline]
+        fn as_f32(self) -> f32 {
+            self as f32
+        }
+
+        #[inline]
+        fn as_f64(self) -> f64 {
+            self
+        }
+
+        #[inline]
+        fn from_f32(f: f32) -> Self {
+            f as f64
+        }
+
+        #[inline]
+        fn from_f64(f: f64) -> Self {
+            f
+        }
+    }
+
+    pub use std::f64::consts;
+
+    /// A 2-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec2 = glam::DVec2;
+    /// A 3-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec3 = glam::DVec3;
+    /// A 4-dimensional vector from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RVec4 = glam::DVec4;
+
+    /// A 2x2 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].  
+    pub type RMat2 = glam::DMat2;
+    /// A 3x3 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat3 = glam::DMat3;
+    /// A 4x4 column-major matrix from [`glam`]. Using a floating-point format compatible with [`real`].
+    pub type RMat4 = glam::DMat4;
+
+    /// A matrix from [`glam`] quaternion representing an orientation. Using a floating-point format
+    /// compatible with [`real`].
+    pub type RQuat = glam::DQuat;
+
+    /// A 2D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine2 = glam::DAffine2;
+    /// A 3D affine transform from [`glam`], which can represent translation, rotation, scaling and
+    /// shear. Using a floating-point format compatible with [`real`].
+    pub type RAffine3 = glam::DAffine3;
+}
+
+pub use crate::real;
+pub(crate) use real_mod::*;
+pub use real_mod::{consts as real_consts, real};
+
+/// A macro to coerce float-literals into the real type. Mainly used where
+/// you'd normally use a suffix to specity the type, such as `115.0f32`.
+///
+/// ### Examples
+/// Rust will not know how to infer the type of this call to `to_radians`:
+/// ```compile_fail
+/// use godot_core::builtin::real;
+///
+/// let radians: real = 115.0.to_radians();
+/// ```
+/// But we can't add a suffix to the literal, since it may be either `f32` or
+/// `f64` depending on the context. So instead we use our macro:
+/// ```
+/// use godot_core::builtin::real;
+///
+/// let radians: real = godot_core::real!(115.0).to_radians();
+/// ```
+#[macro_export]
+macro_rules! real {
+    ($f:literal) => {{
+        let f: $crate::builtin::real = $f;
+        f
+    }};
+}

--- a/godot-core/src/builtin/packed_array.rs
+++ b/godot-core/src/builtin/packed_array.rs
@@ -305,8 +305,8 @@ macro_rules! impl_packed_array {
             }
 
             /// Converts an `$Element` into a value that can be passed into API functions. For most
-            /// types, this is a no-op. But `u8` and `i32` are widened to `i64`, and `f32` is
-            /// widened to `f64`.
+            /// types, this is a no-op. But `u8` and `i32` are widened to `i64`, and `real` is
+            /// widened to `f64` if it is an `f32`.
             #[inline]
             fn into_arg(e: $Element) -> $Arg {
                 e.into()

--- a/godot-core/src/builtin/projection.rs
+++ b/godot-core/src/builtin/projection.rs
@@ -10,8 +10,8 @@ use sys::{ffi_methods, GodotFfi};
 
 use super::glam_helpers::{GlamConv, GlamType};
 use super::{inner::InnerProjection, Plane, Transform3D, Vector2, Vector4};
+use super::{real, RMat4, RealConv};
 
-use glam;
 /// A 4x4 matrix used for 3D projective transformations. It can represent
 /// transformations such as translation, rotation, scaling, shearing, and
 /// perspective division. It consists of four Vector4 columns.
@@ -50,7 +50,7 @@ impl Projection {
     }
 
     /// Create a diagonal matrix from the given values.
-    pub const fn from_diagonal(x: f32, y: f32, z: f32, w: f32) -> Self {
+    pub const fn from_diagonal(x: real, y: real, z: real, w: real) -> Self {
         Self::from_cols(
             Vector4::new(x, 0.0, 0.0, 0.0),
             Vector4::new(0.0, y, 0.0, 0.0),
@@ -83,23 +83,23 @@ impl Projection {
     #[allow(clippy::too_many_arguments)]
     pub fn create_for_hmd(
         eye: ProjectionEye,
-        aspect: f64,
-        intraocular_dist: f64,
-        display_width: f64,
-        display_to_lens: f64,
-        oversample: f64,
-        near: f64,
-        far: f64,
+        aspect: real,
+        intraocular_dist: real,
+        display_width: real,
+        display_to_lens: real,
+        oversample: real,
+        near: real,
+        far: real,
     ) -> Self {
         InnerProjection::create_for_hmd(
             eye as i64,
-            aspect,
-            intraocular_dist,
-            display_width,
-            display_to_lens,
-            oversample,
-            near,
-            far,
+            aspect.as_f64(),
+            intraocular_dist.as_f64(),
+            display_width.as_f64(),
+            display_to_lens.as_f64(),
+            oversample.as_f64(),
+            near.as_f64(),
+            far.as_f64(),
         )
     }
 
@@ -108,14 +108,21 @@ impl Projection {
     ///
     /// _Godot equivalent: Projection.create_frustum()_
     pub fn create_frustum(
-        left: f64,
-        right: f64,
-        bottom: f64,
-        top: f64,
-        near: f64,
-        far: f64,
+        left: real,
+        right: real,
+        bottom: real,
+        top: real,
+        near: real,
+        far: real,
     ) -> Self {
-        InnerProjection::create_frustum(left, right, bottom, top, near, far)
+        InnerProjection::create_frustum(
+            left.as_f64(),
+            right.as_f64(),
+            bottom.as_f64(),
+            top.as_f64(),
+            near.as_f64(),
+            far.as_f64(),
+        )
     }
 
     /// Creates a new Projection that projects positions in a frustum with the
@@ -126,14 +133,21 @@ impl Projection {
     ///
     /// _Godot equivalent: Projection.create_frustum_aspect()_
     pub fn create_frustum_aspect(
-        size: f64,
-        aspect: f64,
+        size: real,
+        aspect: real,
         offset: Vector2,
-        near: f64,
-        far: f64,
+        near: real,
+        far: real,
         flip_fov: bool,
     ) -> Self {
-        InnerProjection::create_frustum_aspect(size, aspect, offset, near, far, flip_fov)
+        InnerProjection::create_frustum_aspect(
+            size.as_f64(),
+            aspect.as_f64(),
+            offset,
+            near.as_f64(),
+            far.as_f64(),
+            flip_fov,
+        )
     }
 
     /// Creates a new Projection that projects positions using an orthogonal
@@ -141,14 +155,21 @@ impl Projection {
     ///
     /// _Godot equivalent: Projection.create_orthogonal()_
     pub fn create_orthogonal(
-        left: f64,
-        right: f64,
-        bottom: f64,
-        top: f64,
-        near: f64,
-        far: f64,
+        left: real,
+        right: real,
+        bottom: real,
+        top: real,
+        near: real,
+        far: real,
     ) -> Self {
-        InnerProjection::create_orthogonal(left, right, bottom, top, near, far)
+        InnerProjection::create_orthogonal(
+            left.as_f64(),
+            right.as_f64(),
+            bottom.as_f64(),
+            top.as_f64(),
+            near.as_f64(),
+            far.as_f64(),
+        )
     }
 
     /// Creates a new Projection that projects positions using an orthogonal
@@ -159,13 +180,19 @@ impl Projection {
     ///
     /// _Godot equivalent: Projection.create_orthogonal_aspect()_
     pub fn create_orthogonal_aspect(
-        size: f64,
-        aspect: f64,
-        near: f64,
-        far: f64,
+        size: real,
+        aspect: real,
+        near: real,
+        far: real,
         flip_fov: bool,
     ) -> Self {
-        InnerProjection::create_orthogonal_aspect(size, aspect, near, far, flip_fov)
+        InnerProjection::create_orthogonal_aspect(
+            size.as_f64(),
+            aspect.as_f64(),
+            near.as_f64(),
+            far.as_f64(),
+            flip_fov,
+        )
     }
 
     /// Creates a new Projection that projects positions using a perspective
@@ -177,13 +204,19 @@ impl Projection {
     ///
     /// _Godot equivalent: Projection.create_perspective()_
     pub fn create_perspective(
-        fov_y: f64,
-        aspect: f64,
-        near: f64,
-        far: f64,
+        fov_y: real,
+        aspect: real,
+        near: real,
+        far: real,
         flip_fov: bool,
     ) -> Self {
-        InnerProjection::create_perspective(fov_y, aspect, near, far, flip_fov)
+        InnerProjection::create_perspective(
+            fov_y.as_f64(),
+            aspect.as_f64(),
+            near.as_f64(),
+            far.as_f64(),
+            flip_fov,
+        )
     }
 
     /// Creates a new Projection that projects positions using a perspective
@@ -198,32 +231,32 @@ impl Projection {
     /// _Godot equivalent: Projection.create_perspective_hmd()_
     #[allow(clippy::too_many_arguments)]
     pub fn create_perspective_hmd(
-        fov_y: f64,
-        aspect: f64,
-        near: f64,
-        far: f64,
+        fov_y: real,
+        aspect: real,
+        near: real,
+        far: real,
         flip_fov: bool,
         eye: ProjectionEye,
-        intraocular_dist: f64,
-        convergence_dist: f64,
+        intraocular_dist: real,
+        convergence_dist: real,
     ) -> Self {
         InnerProjection::create_perspective_hmd(
-            fov_y,
-            aspect,
-            near,
-            far,
+            fov_y.as_f64(),
+            aspect.as_f64(),
+            near.as_f64(),
+            far.as_f64(),
             flip_fov,
             eye as i64,
-            intraocular_dist,
-            convergence_dist,
+            intraocular_dist.as_f64(),
+            convergence_dist.as_f64(),
         )
     }
 
     /// Return the determinant of the matrix.
     ///
     /// _Godot equivalent: Projection.determinant()_
-    pub fn determinant(&self) -> f64 {
-        self.glam(|mat| mat.determinant()) as f64
+    pub fn determinant(&self) -> real {
+        self.glam(|mat| mat.determinant())
     }
 
     /// Returns a copy of this Projection with the signs of the values of the Y
@@ -238,8 +271,8 @@ impl Projection {
     /// Returns the X:Y aspect ratio of this Projection's viewport.
     ///
     /// _Godot equivalent: Projection.get_aspect()_
-    pub fn aspect(&self) -> f64 {
-        self.as_inner().get_aspect()
+    pub fn aspect(&self) -> real {
+        real::from_f64(self.as_inner().get_aspect())
     }
 
     /// Returns the dimensions of the far clipping plane of the projection,
@@ -253,24 +286,24 @@ impl Projection {
     /// Returns the horizontal field of view of the projection (in degrees).
     ///
     /// _Godot equivalent: Projection.get_fov()_
-    pub fn fov(&self) -> f64 {
-        self.as_inner().get_fov()
+    pub fn fov(&self) -> real {
+        real::from_f64(self.as_inner().get_fov())
     }
 
     /// Returns the vertical field of view of a projection (in degrees) which
     /// has the given horizontal field of view (in degrees) and aspect ratio.
     ///
     /// _Godot equivalent: Projection.get_fovy()_
-    pub fn fovy_of(fov_x: f64, aspect: f64) -> f64 {
-        InnerProjection::get_fovy(fov_x, aspect)
+    pub fn fovy_of(fov_x: real, aspect: real) -> real {
+        real::from_f64(InnerProjection::get_fovy(fov_x.as_f64(), aspect.as_f64()))
     }
 
     /// Returns the factor by which the visible level of detail is scaled by
     /// this Projection.
     ///
     /// _Godot equivalent: Projection.get_lod_multiplier()_
-    pub fn lod_multiplier(&self) -> f64 {
-        self.as_inner().get_lod_multiplier()
+    pub fn lod_multiplier(&self) -> real {
+        real::from_f64(self.as_inner().get_lod_multiplier())
     }
 
     /// Returns the number of pixels with the given pixel width displayed per
@@ -301,16 +334,16 @@ impl Projection {
     /// clipped.
     ///
     /// _Godot equivalent: Projection.get_z_far()_
-    pub fn z_far(&self) -> f64 {
-        self.as_inner().get_z_far()
+    pub fn z_far(&self) -> real {
+        real::from_f64(self.as_inner().get_z_far())
     }
 
     /// Returns the distance for this Projection before which positions are
     /// clipped.
     ///
     /// _Godot equivalent: Projection.get_z_near()_
-    pub fn z_near(&self) -> f64 {
-        self.as_inner().get_z_near()
+    pub fn z_near(&self) -> real {
+        real::from_f64(self.as_inner().get_z_near())
     }
 
     /// Returns a Projection that performs the inverse of this Projection's
@@ -343,8 +376,9 @@ impl Projection {
     /// Note: The original Projection must be a perspective projection.
     ///
     /// _Godot equivalent: Projection.perspective_znear_adjusted()_
-    pub fn perspective_znear_adjusted(&self, new_znear: f64) -> Self {
-        self.as_inner().perspective_znear_adjusted(new_znear)
+    pub fn perspective_znear_adjusted(&self, new_znear: real) -> Self {
+        self.as_inner()
+            .perspective_znear_adjusted(new_znear.as_f64())
     }
 
     #[doc(hidden)]
@@ -355,7 +389,7 @@ impl Projection {
 
 impl From<Transform3D> for Projection {
     fn from(trans: Transform3D) -> Self {
-        trans.glam(glam::Mat4::from)
+        trans.glam(RMat4::from)
     }
 }
 
@@ -381,7 +415,7 @@ impl Mul<Vector4> for Projection {
     }
 }
 
-impl GlamType for glam::Mat4 {
+impl GlamType for RMat4 {
     type Mapped = Projection;
 
     fn to_front(&self) -> Self::Mapped {
@@ -399,7 +433,7 @@ impl GlamType for glam::Mat4 {
 }
 
 impl GlamConv for Projection {
-    type Glam = glam::Mat4;
+    type Glam = RMat4;
 }
 
 impl GodotFfi for Projection {

--- a/godot-core/src/builtin/quaternion.rs
+++ b/godot-core/src/builtin/quaternion.rs
@@ -11,23 +11,24 @@ use sys::{ffi_methods, GodotFfi};
 use crate::builtin::glam_helpers::{GlamConv, GlamType};
 use crate::builtin::{inner, math::*, vector3::*};
 
+use super::{real, RQuat};
 use super::{Basis, EulerOrder};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 #[repr(C)]
 pub struct Quaternion {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-    pub w: f32,
+    pub x: real,
+    pub y: real,
+    pub z: real,
+    pub w: real,
 }
 
 impl Quaternion {
-    pub fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
+    pub fn new(x: real, y: real, z: real, w: real) -> Self {
         Self { x, y, z, w }
     }
 
-    pub fn from_angle_axis(axis: Vector3, angle: f32) -> Self {
+    pub fn from_angle_axis(axis: Vector3, angle: real) -> Self {
         let d = axis.length();
         if d == 0.0 {
             Self::new(0.0, 0.0, 0.0, 0.0)
@@ -43,12 +44,12 @@ impl Quaternion {
         }
     }
 
-    pub fn angle_to(self, to: Self) -> f32 {
-        self.glam2(&to, glam::f32::Quat::angle_between)
+    pub fn angle_to(self, to: Self) -> real {
+        self.glam2(&to, RQuat::angle_between)
     }
 
-    pub fn dot(self, with: Self) -> f32 {
-        self.glam2(&with, glam::f32::Quat::dot)
+    pub fn dot(self, with: Self) -> real {
+        self.glam2(&with, RQuat::dot)
     }
 
     pub fn to_exp(self) -> Self {
@@ -82,7 +83,7 @@ impl Quaternion {
         )
     }
 
-    pub fn get_angle(self) -> f32 {
+    pub fn get_angle(self) -> real {
         2.0 * self.w.acos()
     }
 
@@ -121,11 +122,11 @@ impl Quaternion {
         is_equal_approx(self.length_squared(), 1.0)
     }
 
-    pub fn length(self) -> f32 {
+    pub fn length(self) -> real {
         self.length_squared().sqrt()
     }
 
-    pub fn length_squared(self) -> f32 {
+    pub fn length_squared(self) -> real {
         self.dot(self)
     }
 
@@ -138,13 +139,13 @@ impl Quaternion {
         self / self.length()
     }
 
-    pub fn slerp(self, to: Self, weight: f32) -> Self {
+    pub fn slerp(self, to: Self, weight: real) -> Self {
         let mut cosom = self.dot(to);
         let to1: Self;
-        let omega: f32;
-        let sinom: f32;
-        let scale0: f32;
-        let scale1: f32;
+        let omega: real;
+        let sinom: real;
+        let scale0: real;
+        let scale1: real;
         if cosom < 0.0 {
             cosom = -cosom;
             to1 = -to;
@@ -165,7 +166,7 @@ impl Quaternion {
         scale0 * self + scale1 * to1
     }
 
-    pub fn slerpni(self, to: Self, weight: f32) -> Self {
+    pub fn slerpni(self, to: Self, weight: real) -> Self {
         let dot = self.dot(to);
         if dot.abs() > 0.9999 {
             return self;
@@ -178,7 +179,7 @@ impl Quaternion {
         inv_factor * self + new_factor * to
     }
 
-    // pub fn spherical_cubic_interpolate(self, b: Self, pre_a: Self, post_b: Self, weight: f32) -> Self {}
+    // pub fn spherical_cubic_interpolate(self, b: Self, pre_a: Self, post_b: Self, weight: real) -> Self {}
     // TODO: Implement godot's function in rust
     /*
         pub fn spherical_cubic_interpolate_in_time(
@@ -186,10 +187,10 @@ impl Quaternion {
             b: Self,
             pre_a: Self,
             post_b: Self,
-            weight: f32,
-            b_t: f32,
-            pre_a_t: f32,
-            post_b_t: f32,
+            weight: real,
+            b_t: real,
+            pre_a_t: real,
+            post_b_t: real,
         ) -> Self {
         }
     */
@@ -242,7 +243,7 @@ impl Mul<Quaternion> for Quaternion {
     type Output = Self;
 
     fn mul(self, other: Quaternion) -> Self {
-        // TODO use glam?
+        // TODO use super::glam?
 
         let x = self.w * other.x + self.x * other.w + self.y * other.z - self.z * other.y;
         let y = self.w * other.y + self.y * other.w + self.z * other.x - self.x * other.z;
@@ -270,10 +271,10 @@ impl Default for Quaternion {
 }
 
 impl GlamConv for Quaternion {
-    type Glam = glam::f32::Quat;
+    type Glam = RQuat;
 }
 
-impl GlamType for glam::f32::Quat {
+impl GlamType for RQuat {
     type Mapped = Quaternion;
 
     fn to_front(&self) -> Self::Mapped {
@@ -281,7 +282,7 @@ impl GlamType for glam::f32::Quat {
     }
 
     fn from_front(mapped: &Self::Mapped) -> Self {
-        glam::f32::Quat::from_xyzw(mapped.x, mapped.y, mapped.z, mapped.w)
+        RQuat::from_xyzw(mapped.x, mapped.y, mapped.z, mapped.w)
     }
 }
 
@@ -291,10 +292,10 @@ impl MulAssign<Quaternion> for Quaternion {
     }
 }
 
-impl Mul<f32> for Quaternion {
+impl Mul<real> for Quaternion {
     type Output = Self;
 
-    fn mul(self, other: f32) -> Self {
+    fn mul(self, other: real) -> Self {
         Quaternion::new(
             self.x * other,
             self.y * other,
@@ -304,7 +305,7 @@ impl Mul<f32> for Quaternion {
     }
 }
 
-impl Mul<Quaternion> for f32 {
+impl Mul<Quaternion> for real {
     type Output = Quaternion;
 
     fn mul(self, other: Quaternion) -> Quaternion {
@@ -312,16 +313,16 @@ impl Mul<Quaternion> for f32 {
     }
 }
 
-impl MulAssign<f32> for Quaternion {
-    fn mul_assign(&mut self, other: f32) {
+impl MulAssign<real> for Quaternion {
+    fn mul_assign(&mut self, other: real) {
         *self = *self * other
     }
 }
 
-impl Div<f32> for Quaternion {
+impl Div<real> for Quaternion {
     type Output = Self;
 
-    fn div(self, other: f32) -> Self {
+    fn div(self, other: real) -> Self {
         Self::new(
             self.x / other,
             self.y / other,
@@ -331,8 +332,8 @@ impl Div<f32> for Quaternion {
     }
 }
 
-impl DivAssign<f32> for Quaternion {
-    fn div_assign(&mut self, other: f32) {
+impl DivAssign<real> for Quaternion {
+    fn div_assign(&mut self, other: real) {
         *self = *self / other
     }
 }

--- a/godot-core/src/builtin/vector3.rs
+++ b/godot-core/src/builtin/vector3.rs
@@ -7,8 +7,6 @@ use std::ops::*;
 
 use std::fmt;
 
-use glam::f32::Vec3;
-use glam::Vec3A;
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
@@ -17,6 +15,7 @@ use crate::builtin::Vector3i;
 
 use super::glam_helpers::GlamConv;
 use super::glam_helpers::GlamType;
+use super::{real, RVec3};
 
 /// Vector used for 3D math using floating point coordinates.
 ///
@@ -32,11 +31,11 @@ use super::glam_helpers::GlamType;
 #[repr(C)]
 pub struct Vector3 {
     /// The vector's X component.
-    pub x: f32,
+    pub x: real,
     /// The vector's Y component.
-    pub y: f32,
+    pub y: real,
     /// The vector's Z component.
-    pub z: f32,
+    pub z: real,
 }
 
 impl Vector3 {
@@ -65,39 +64,39 @@ impl Vector3 {
     pub const BACK: Self = Self::new(0.0, 0.0, 1.0);
 
     /// Returns a `Vector3` with the given components.
-    pub const fn new(x: f32, y: f32, z: f32) -> Self {
+    pub const fn new(x: real, y: real, z: real) -> Self {
         Self { x, y, z }
     }
 
     /// Returns a new `Vector3` with all components set to `v`.
-    pub const fn splat(v: f32) -> Self {
+    pub const fn splat(v: real) -> Self {
         Self::new(v, v, v)
     }
 
     /// Constructs a new `Vector3` from a [`Vector3i`].
     pub const fn from_vector3i(v: Vector3i) -> Self {
         Self {
-            x: v.x as f32,
-            y: v.y as f32,
-            z: v.z as f32,
+            x: v.x as real,
+            y: v.y as real,
+            z: v.z as real,
         }
     }
 
     /// Converts the corresponding `glam` type to `Self`.
-    fn from_glam(v: glam::Vec3) -> Self {
+    fn from_glam(v: RVec3) -> Self {
         Self::new(v.x, v.y, v.z)
     }
 
     /// Converts `self` to the corresponding `glam` type.
-    fn to_glam(self) -> glam::Vec3 {
-        glam::Vec3::new(self.x, self.y, self.z)
+    fn to_glam(self) -> RVec3 {
+        RVec3::new(self.x, self.y, self.z)
     }
 
-    pub fn angle_to(self, to: Self) -> f32 {
+    pub fn angle_to(self, to: Self) -> real {
         self.to_glam().angle_between(to.to_glam())
     }
 
-    pub fn bezier_derivative(self, control_1: Self, control_2: Self, end: Self, t: f32) -> Self {
+    pub fn bezier_derivative(self, control_1: Self, control_2: Self, end: Self, t: real) -> Self {
         let x = bezier_derivative(self.x, control_1.x, control_2.x, end.x, t);
         let y = bezier_derivative(self.y, control_1.y, control_2.y, end.y, t);
         let z = bezier_derivative(self.z, control_1.z, control_2.z, end.z, t);
@@ -105,7 +104,7 @@ impl Vector3 {
         Self::new(x, y, z)
     }
 
-    pub fn bezier_interpolate(self, control_1: Self, control_2: Self, end: Self, t: f32) -> Self {
+    pub fn bezier_interpolate(self, control_1: Self, control_2: Self, end: Self, t: real) -> Self {
         let x = bezier_interpolate(self.x, control_1.x, control_2.x, end.x, t);
         let y = bezier_interpolate(self.y, control_1.y, control_2.y, end.y, t);
         let z = bezier_interpolate(self.z, control_1.z, control_2.z, end.z, t);
@@ -129,7 +128,7 @@ impl Vector3 {
         Self::from_glam(self.to_glam().cross(with.to_glam()))
     }
 
-    pub fn cubic_interpolate(self, b: Self, pre_a: Self, post_b: Self, weight: f32) -> Self {
+    pub fn cubic_interpolate(self, b: Self, pre_a: Self, post_b: Self, weight: real) -> Self {
         let x = cubic_interpolate(self.x, b.x, pre_a.x, post_b.x, weight);
         let y = cubic_interpolate(self.y, b.y, pre_a.y, post_b.y, weight);
         let z = cubic_interpolate(self.z, b.z, pre_a.z, post_b.z, weight);
@@ -143,10 +142,10 @@ impl Vector3 {
         b: Self,
         pre_a: Self,
         post_b: Self,
-        weight: f32,
-        b_t: f32,
-        pre_a_t: f32,
-        post_b_t: f32,
+        weight: real,
+        b_t: real,
+        pre_a_t: real,
+        post_b_t: real,
     ) -> Self {
         let x = cubic_interpolate_in_time(
             self.x, b.x, pre_a.x, post_b.x, weight, b_t, pre_a_t, post_b_t,
@@ -165,15 +164,15 @@ impl Vector3 {
         (to - self).normalized()
     }
 
-    pub fn distance_squared_to(self, to: Self) -> f32 {
+    pub fn distance_squared_to(self, to: Self) -> real {
         (to - self).length_squared()
     }
 
-    pub fn distance_to(self, to: Self) -> f32 {
+    pub fn distance_to(self, to: Self) -> real {
         (to - self).length()
     }
 
-    pub fn dot(self, with: Self) -> f32 {
+    pub fn dot(self, with: Self) -> real {
         self.to_glam().dot(with.to_glam())
     }
 
@@ -203,15 +202,15 @@ impl Vector3 {
         is_zero_approx(self.x) && is_zero_approx(self.y) && is_zero_approx(self.z)
     }
 
-    pub fn length_squared(self) -> f32 {
+    pub fn length_squared(self) -> real {
         self.to_glam().length_squared()
     }
 
-    pub fn lerp(self, to: Self, weight: f32) -> Self {
+    pub fn lerp(self, to: Self, weight: real) -> Self {
         Self::from_glam(self.to_glam().lerp(to.to_glam(), weight))
     }
 
-    pub fn limit_length(self, length: Option<f32>) -> Self {
+    pub fn limit_length(self, length: Option<real>) -> Self {
         Self::from_glam(self.to_glam().clamp_length_max(length.unwrap_or(1.0)))
     }
 
@@ -243,7 +242,7 @@ impl Vector3 {
         }
     }
 
-    pub fn move_toward(self, to: Self, delta: f32) -> Self {
+    pub fn move_toward(self, to: Self, delta: real) -> Self {
         let vd = to - self;
         let len = vd.length();
         if len <= delta || len < CMP_EPSILON {
@@ -253,7 +252,7 @@ impl Vector3 {
         }
     }
 
-    pub fn posmod(self, pmod: f32) -> Self {
+    pub fn posmod(self, pmod: real) -> Self {
         Self::new(
             fposmod(self.x, pmod),
             fposmod(self.y, pmod),
@@ -285,7 +284,7 @@ impl Vector3 {
         Self::new(sign(self.x), sign(self.y), sign(self.z))
     }
 
-    pub fn signed_angle_to(self, to: Self, axis: Self) -> f32 {
+    pub fn signed_angle_to(self, to: Self, axis: Self) -> real {
         let cross_to = self.cross(to);
         let unsigned_angle = self.dot(to).atan2(cross_to.length());
         let sign = cross_to.dot(axis);
@@ -316,10 +315,10 @@ impl fmt::Display for Vector3 {
     }
 }
 
-impl_common_vector_fns!(Vector3, f32);
-impl_float_vector_fns!(Vector3, f32);
-impl_vector_operators!(Vector3, f32, (x, y, z));
-impl_vector_index!(Vector3, f32, (x, y, z), Vector3Axis, (X, Y, Z));
+impl_common_vector_fns!(Vector3, real);
+impl_float_vector_fns!(Vector3, real);
+impl_vector_operators!(Vector3, real, (x, y, z));
+impl_vector_index!(Vector3, real, (x, y, z), Vector3Axis, (X, Y, Z));
 
 impl GodotFfi for Vector3 {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
@@ -342,7 +341,7 @@ impl GodotFfi for Vector3Axis {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }
 
-impl GlamType for Vec3 {
+impl GlamType for RVec3 {
     type Mapped = Vector3;
 
     fn to_front(&self) -> Self::Mapped {
@@ -350,11 +349,12 @@ impl GlamType for Vec3 {
     }
 
     fn from_front(mapped: &Self::Mapped) -> Self {
-        Vec3::new(mapped.x, mapped.y, mapped.z)
+        RVec3::new(mapped.x, mapped.y, mapped.z)
     }
 }
 
-impl GlamType for Vec3A {
+#[cfg(not(feature = "double-precision"))]
+impl GlamType for glam::Vec3A {
     type Mapped = Vector3;
 
     fn to_front(&self) -> Self::Mapped {
@@ -362,10 +362,10 @@ impl GlamType for Vec3A {
     }
 
     fn from_front(mapped: &Self::Mapped) -> Self {
-        Vec3A::new(mapped.x, mapped.y, mapped.z)
+        glam::Vec3A::new(mapped.x, mapped.y, mapped.z)
     }
 }
 
 impl GlamConv for Vector3 {
-    type Glam = Vec3;
+    type Glam = RVec3;
 }

--- a/godot-core/src/builtin/vector4.rs
+++ b/godot-core/src/builtin/vector4.rs
@@ -6,13 +6,13 @@
 
 use std::fmt;
 
-use glam::Vec4;
 use godot_ffi as sys;
 use sys::{ffi_methods, GodotFfi};
 
 use crate::builtin::Vector4i;
 
 use super::glam_helpers::{GlamConv, GlamType};
+use super::{real, RVec4};
 
 /// Vector used for 4D math using floating point coordinates.
 ///
@@ -27,38 +27,38 @@ use super::glam_helpers::{GlamConv, GlamType};
 #[repr(C)]
 pub struct Vector4 {
     /// The vector's X component.
-    pub x: f32,
+    pub x: real,
     /// The vector's Y component.
-    pub y: f32,
+    pub y: real,
     /// The vector's Z component.
-    pub z: f32,
+    pub z: real,
     /// The vector's W component.
-    pub w: f32,
+    pub w: real,
 }
 
-impl_vector_operators!(Vector4, f32, (x, y, z, w));
-impl_vector_index!(Vector4, f32, (x, y, z, w), Vector4Axis, (X, Y, Z, W));
-impl_common_vector_fns!(Vector4, f32);
-impl_float_vector_fns!(Vector4, f32);
+impl_vector_operators!(Vector4, real, (x, y, z, w));
+impl_vector_index!(Vector4, real, (x, y, z, w), Vector4Axis, (X, Y, Z, W));
+impl_common_vector_fns!(Vector4, real);
+impl_float_vector_fns!(Vector4, real);
 
 impl Vector4 {
     /// Returns a `Vector4` with the given components.
-    pub const fn new(x: f32, y: f32, z: f32, w: f32) -> Self {
+    pub const fn new(x: real, y: real, z: real, w: real) -> Self {
         Self { x, y, z, w }
     }
 
     /// Returns a new `Vector4` with all components set to `v`.
-    pub const fn splat(v: f32) -> Self {
+    pub const fn splat(v: real) -> Self {
         Self::new(v, v, v, v)
     }
 
     /// Constructs a new `Vector3` from a [`Vector3i`].
     pub const fn from_vector4i(v: Vector4i) -> Self {
         Self {
-            x: v.x as f32,
-            y: v.y as f32,
-            z: v.z as f32,
-            w: v.w as f32,
+            x: v.x as real,
+            y: v.y as real,
+            z: v.z as real,
+            w: v.w as real,
         }
     }
 
@@ -68,17 +68,17 @@ impl Vector4 {
     /// One vector, a vector with all components set to `1.0`.
     pub const ONE: Self = Self::splat(1.0);
 
-    /// Infinity vector, a vector with all components set to `f32::INFINITY`.
-    pub const INF: Self = Self::splat(f32::INFINITY);
+    /// Infinity vector, a vector with all components set to `real::INFINITY`.
+    pub const INF: Self = Self::splat(real::INFINITY);
 
     /// Converts the corresponding `glam` type to `Self`.
-    fn from_glam(v: glam::Vec4) -> Self {
+    fn from_glam(v: RVec4) -> Self {
         Self::new(v.x, v.y, v.z, v.w)
     }
 
     /// Converts `self` to the corresponding `glam` type.
-    fn to_glam(self) -> glam::Vec4 {
-        glam::Vec4::new(self.x, self.y, self.z, self.w)
+    fn to_glam(self) -> RVec4 {
+        RVec4::new(self.x, self.y, self.z, self.w)
     }
 }
 
@@ -111,7 +111,7 @@ impl GodotFfi for Vector4Axis {
     ffi_methods! { type sys::GDExtensionTypePtr = *mut Self; .. }
 }
 
-impl GlamType for Vec4 {
+impl GlamType for RVec4 {
     type Mapped = Vector4;
 
     fn to_front(&self) -> Self::Mapped {
@@ -119,10 +119,10 @@ impl GlamType for Vec4 {
     }
 
     fn from_front(mapped: &Self::Mapped) -> Self {
-        Vec4::new(mapped.x, mapped.y, mapped.z, mapped.w)
+        RVec4::new(mapped.x, mapped.y, mapped.z, mapped.w)
     }
 }
 
 impl GlamConv for Vector4 {
-    type Glam = Vec4;
+    type Glam = RVec4;
 }

--- a/godot-core/src/builtin/vector_macros.rs
+++ b/godot-core/src/builtin/vector_macros.rs
@@ -167,7 +167,7 @@ macro_rules! impl_vector_operators {
     (
         // Name of the vector type to be implemented, for example `Vector2`.
         $Vector:ty,
-        // Type of each individual component, for example `f32`.
+        // Type of each individual component, for example `real`.
         $Scalar:ty,
         // Names of the components, with parentheses, for example `(x, y)`.
         ($($components:ident),*)
@@ -194,7 +194,7 @@ macro_rules! impl_vector_index {
     (
         // Name of the vector type to be implemented, for example `Vector2`.
         $Vector:ty,
-        // Type of each individual component, for example `f32`.
+        // Type of each individual component, for example `real`.
         $Scalar:ty,
         // Names of the components, with parentheses, for example `(x, y)`.
         ($($components:ident),*),
@@ -228,7 +228,7 @@ macro_rules! impl_common_vector_fns {
     (
         // Name of the vector type.
         $Vector:ty,
-        // Type of target component, for example `f32`.
+        // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
         impl $Vector {
@@ -248,7 +248,7 @@ macro_rules! impl_float_vector_fns {
     (
         // Name of the vector type.
         $Vector:ty,
-        // Type of target component, for example `f32`.
+        // Type of target component, for example `real`.
         $Scalar:ty
     ) => {
         impl $Vector {

--- a/godot/Cargo.toml
+++ b/godot/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["game-engines", "graphics"]
 default = ["codegen-full"]
 formatted = ["godot-core/codegen-fmt"]
 trace = ["godot-core/trace"]
+double-precision = ["godot-core/double-precision"]
 
 # Private features, they are under no stability guarantee
 codegen-full = ["godot-core/codegen-full"]

--- a/itest/rust/Cargo.toml
+++ b/itest/rust/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 [features]
 default = []
 trace = ["godot/trace"]
+double-precision = ["godot/double-precision"]
 
 [dependencies]
 godot = { path = "../../godot", default-features = false, features = ["formatted"] }

--- a/itest/rust/src/basis_test.rs
+++ b/itest/rust/src/basis_test.rs
@@ -143,7 +143,7 @@ fn basis_equiv() {
         assert_eq_approx!(
             inner,
             outer,
-            |a, b| is_equal_approx(a as f32, b),
+            |a, b| is_equal_approx(real::from_f64(a), b),
             "function: {name}\n"
         );
     }

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -23,6 +23,8 @@ mod packed_array_test;
 mod quaternion_test;
 mod singleton_test;
 mod string_test;
+mod transform2d_test;
+mod transform3d_test;
 mod utilities_test;
 mod variant_test;
 mod virtual_methods_test;

--- a/itest/rust/src/transform2d_test.rs
+++ b/itest/rust/src/transform2d_test.rs
@@ -44,19 +44,19 @@ fn transform2d_equiv() {
     assert_eq_approx!(
         inner.get_rotation(),
         outer.rotation(),
-        |a, b| is_equal_approx(a as f32, b),
+        |a, b| is_equal_approx(real::from_f64(a), b),
         "function: get_rotation\n"
     );
     assert_eq_approx!(
         inner.get_rotation(),
         outer.rotation(),
-        |a, b| is_equal_approx(a as f32, b),
+        |a, b| is_equal_approx(real::from_f64(a), b),
         "function: get_rotation\n"
     );
     assert_eq_approx!(
         inner.get_skew(),
         outer.skew(),
-        |a, b| is_equal_approx(a as f32, b),
+        |a, b| is_equal_approx(real::from_f64(a), b),
         "function: get_scale\n"
     );
 }


### PR DESCRIPTION
Add a feature `precision-double` which when enabled will make the various structs that use `real_t` in godot have `f64` values instead of `f32` values.
Add a type `real` which is an alias for `f32` or `f64` depending on the above
Add the ability to pass `--features features` to `check.sh`, so we can easily run `check.sh` with `precision-double` enabled
Add double-builds in the full-ci
Add double-build in the minimal-ci for clippy

One question:
Should we maintain the `glam::Vec2` convention somehow? maybe make a module `glam_real` and do `glam_real::RVec2`?

Resolves #135 