### PR TITLE
Implement more Variant accessors

### DIFF
--- a/godot-core/src/builtin/variant/mod.rs
+++ b/godot-core/src/builtin/variant/mod.rs
@@ -156,13 +156,27 @@ impl Variant {
         }
     }
 
+    /// return a `GodotString` representing the variant
     #[allow(unused_mut)]
-    pub(crate) fn stringify(&self) -> GodotString {
+    pub fn stringify(&self) -> GodotString {
         let mut result = GodotString::new();
         unsafe {
             interface_fn!(variant_stringify)(self.var_sys(), result.string_sys());
         }
         result
+    }
+
+    /// return the hash value of the variant.
+    ///
+    /// _Godot equivalent : `@GlobalScope.hash()`_
+    pub fn hash(&self) -> i64 {
+        unsafe { interface_fn!(variant_hash)(self.var_sys()) }
+    }
+
+    /// return a false only if the variant is `Variant::NIL`
+    /// or an empty `TypedArray` or `Dictionary`.
+    pub fn booleanize(&self) -> bool {
+        unsafe { interface_fn!(variant_booleanize)(self.var_sys()) != 0 }
     }
 
     fn from_opaque(opaque: OpaqueVariant) -> Self {


### PR DESCRIPTION
Closes #140

The test for stringify are looking pretty good in my opinion

This is not ready to merge :
[ ] Discuss mapped method returned type (sys::GDExtensionBool, sys::GDExtensionInt, etc)
[ ] Test all mapped method
[ ] remove itest(focus)
[ ] squash the commits

Currently I wrote this kind of code, I have
```rust
 pub fn booleanize(&self) -> sys::GDExtensionBool {
        interface_fn!(variant_booleanize)(self.var_sys())
    }
```
Which is bad cause we probably don't want sys::GDExtensionBool to be seen by users, instead I guess it should return a regular rust boolean but I'm unsure how to do the conversion yet, it's probably somewhere in the code

