### PR TITLE
Inject scene tree into `#[itest]`

### DIFF
--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -220,7 +220,7 @@ impl<T: GodotClass> Gd<T> {
         // Initialize instance ID cache
         let id = unsafe { interface_fn!(object_get_instance_id)(obj.obj_sys()) };
         let instance_id = InstanceId::try_from_u64(id)
-            .expect("instance ID must be non-zero at time of initialization");
+            .expect("Gd initialization failed; did you call share() on a dead instance?");
         obj.cached_instance_id.set(Some(instance_id));
 
         obj
@@ -452,7 +452,7 @@ where
         // If ref_counted returned None, that means the instance was destroyed
         assert!(
             ref_counted == Some(false) && self.is_instance_valid(),
-            "called free() on already destroyed obj"
+            "called free() on already destroyed object"
         );
 
         // This destroys the Storage instance, no need to run destructor again

--- a/godot-core/src/obj/gd.rs
+++ b/godot-core/src/obj/gd.rs
@@ -671,3 +671,8 @@ impl<T: GodotClass> VariantMetadata for Gd<T> {
         ClassName::of::<T>()
     }
 }
+
+// Gd unwinding across panics does not invalidate any invariants;
+// its mutability is anyway present, in the Godot engine.
+impl<T: GodotClass> std::panic::UnwindSafe for Gd<T> {}
+impl<T: GodotClass> std::panic::RefUnwindSafe for Gd<T> {}

--- a/itest/godot/.godot/global_script_class_cache.cfg
+++ b/itest/godot/.godot/global_script_class_cache.cfg
@@ -1,13 +1,13 @@
-list=[{
+list=Array[Dictionary]([{
 "base": &"RefCounted",
 "class": &"TestStats",
 "icon": "",
 "language": &"GDScript",
 "path": "res://TestStats.gd"
 }, {
-"base": &"Node",
+"base": &"RefCounted",
 "class": &"TestSuite",
 "icon": "",
 "language": &"GDScript",
 "path": "res://TestSuite.gd"
-}]
+}])

--- a/itest/godot/TestRunner.gd
+++ b/itest/godot/TestRunner.gd
@@ -33,7 +33,12 @@ func _ready():
 			if method_name.begins_with("test_"):
 				gdscript_tests.push_back(GDScriptTestCase.new(suite, method_name))
 
-	var success: bool = rust_runner.run_all_tests(gdscript_tests, gdscript_suites.size(), allow_focus)
+	var success: bool = rust_runner.run_all_tests(
+		gdscript_tests,
+		gdscript_suites.size(),
+		allow_focus,
+		self,
+	)
 
 	var exit_code: int = 0 if success else 1
 	get_tree().quit(exit_code)

--- a/itest/rust/src/lib.rs
+++ b/itest/rust/src/lib.rs
@@ -4,7 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use godot::engine::Node;
 use godot::init::{gdextension, ExtensionLibrary};
+use godot::obj::Gd;
 use godot::sys;
 
 mod array_test;
@@ -89,6 +91,10 @@ fn collect_rust_tests() -> (Vec<RustTestCase>, usize, bool) {
     (tests, all_files.len(), is_focus_run)
 }
 
+pub struct TestContext {
+    scene_tree: Gd<Node>,
+}
+
 #[derive(Copy, Clone)]
 struct RustTestCase {
     name: &'static str,
@@ -98,5 +104,5 @@ struct RustTestCase {
     focused: bool,
     #[allow(dead_code)]
     line: u32,
-    function: fn(),
+    function: fn(&TestContext),
 }

--- a/itest/rust/src/object_test.rs
+++ b/itest/rust/src/object_test.rs
@@ -4,19 +4,21 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::{expect_panic, itest};
+use std::cell::RefCell;
+use std::mem;
+use std::rc::Rc;
+
 use godot::bind::{godot_api, GodotClass, GodotExt};
 use godot::builtin::{
     FromVariant, GodotString, StringName, ToVariant, Variant, VariantConversionError, Vector3,
 };
+use godot::engine::node::InternalMode;
 use godot::engine::{file_access, Area2D, Camera3D, FileAccess, Node, Node3D, Object, RefCounted};
 use godot::obj::{Base, Gd, InstanceId};
 use godot::obj::{Inherits, Share};
 use godot::sys::GodotFfi;
 
-use std::cell::RefCell;
-use std::mem;
-use std::rc::Rc;
+use crate::{expect_panic, itest, TestContext};
 
 // TODO:
 // * make sure that ptrcalls are used when possible (ie. when type info available; maybe GDScript integration test)
@@ -595,6 +597,17 @@ fn object_call_with_args() {
     assert_eq!(actual_pos, expected_pos.to_variant());
     node.free();
 }
+
+#[itest]
+fn object_get_scene_tree(ctx: &TestContext) {
+    let node = Node3D::new_alloc();
+
+    let mut tree = ctx.scene_tree.share();
+    tree.add_child(node.upcast(), false, InternalMode::INTERNAL_MODE_DISABLED);
+
+    let count = tree.get_child_count(false);
+    assert_eq!(count, 1);
+} // implicitly tested: node does not leak
 
 // ----------------------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Also adds another test for `Gd::eq()` in the case of dead instances, and a stub for testing #23.

Simplifies the proc-macro machinery further.
